### PR TITLE
updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,8 @@ add_compile_options(
 
 # Libraries
 add_subdirectory("src/malloc")
-add_subdirectory("src/sys/${CMAKE_SYSTEM_NAME}")
+string(TOLOWER ${CMAKE_SYSTEM_NAME} SYSTEM_NAME_LOWER)
+add_subdirectory("src/sys/${SYSTEM_NAME_LOWER}")
 add_subdirectory("src/runtime-${RUNTIME}")
 add_subdirectory("src/NXFoundation")
 

--- a/cmake/aarch64-darwin-apple.cmake
+++ b/cmake/aarch64-darwin-apple.cmake
@@ -1,6 +1,6 @@
 # ARM/Darwin target toolchain file
 
-set(CMAKE_SYSTEM_NAME "darwin")
+set(CMAKE_SYSTEM_NAME "Darwin")
 set(CMAKE_SYSTEM_PROCESSOR "arm64")
 
 find_program(CMAKE_C_COMPILER NAMES "gcc-15"

--- a/cmake/armv6m-none-eabi.cmake
+++ b/cmake/armv6m-none-eabi.cmake
@@ -1,6 +1,6 @@
 # RP2040 target toolchain file
 
-set(CMAKE_SYSTEM_NAME "pico")
+set(CMAKE_SYSTEM_NAME "Pico")
 set(CMAKE_SYSTEM_PROCESSOR "cortex-m0plus")
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 

--- a/cmake/x86_64-linux-gnu.cmake
+++ b/cmake/x86_64-linux-gnu.cmake
@@ -1,6 +1,6 @@
 # x86_64/Linux target toolchain file
 
-set(CMAKE_SYSTEM_NAME "linux")
+set(CMAKE_SYSTEM_NAME "Linux")
 set(CMAKE_SYSTEM_PROCESSOR "x86-64")
 
 # Use CC environment variable if set, otherwise default to gcc then clang

--- a/src/NXFoundation/NXZone+arena.c
+++ b/src/NXFoundation/NXZone+arena.c
@@ -31,10 +31,6 @@ struct objc_arena_alloc {
   void *ptr;
 };
 
-// Convenience typedefs
-typedef struct objc_arena objc_arena_t;
-typedef struct objc_arena_alloc objc_arena_alloc_t;
-
 #pragma mark Lifecycle
 
 /**


### PR DESCRIPTION
This PR standardizes CMAKE_SYSTEM_NAME values to use proper case (capitalized) while maintaining compatibility with existing directory structures that expect lowercase names.

Updates CMAKE_SYSTEM_NAME values from lowercase to proper case across platform toolchain files
Removes unused typedef declarations in NXFoundation source
Adds string conversion logic to handle case differences between CMAKE_SYSTEM_NAME and directory paths