### PR TITLE
Updated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,18 @@ CC=clang TARGET=armv6m-none-eabi TOOLCHAIN_PATH=/opt/LLVM-ET-Arm-19.1.5-Darwin-u
 - [X] Resolving super classes and meta classes for message lookup
 - [X] Calling methods in super classes - implement `[super init]` for example
 - [X] Calling methods in categories
+- [X] clang compatibility
 - [ ] Calling `+[initialise]` for categories
-- [ ] clang compatibility
 - [ ] `respondsToSelector:` and `+[Class load]`
 - [ ] More efficient method implementation lookup
 - [ ] Memory management - alloc, dealloc, memory arenas - require malloc in an `NXZone`
 - [ ] Memory management - retain, release - reference counting for objects through NXZone
 - [ ] String - `NXString` - mutable strings
+- [ ] Number - `NXNumber` - immutable numbers
 - [ ] Array and Map - `NXArray` and `NXDictionary`
+- [ ] Date and Time - `NXDate` - mutable date and time
 - [ ] `NXApplication` and `NXRunLoop`
+- [ ] JSON - `NXCoder` - JSON / Binary marshalling and unmarshalling
 - [ ] Pico toolchain - integrate with Pico SDK
 - [ ] Protocols and `conformsToProtocol:`
 - [ ] Threading & `@synchronized` support

--- a/src/NXFoundation/CMakeLists.txt
+++ b/src/NXFoundation/CMakeLists.txt
@@ -4,6 +4,8 @@ add_library(${NAME} STATIC
     NXApplication.m
     NXArch.m
     NXAutoreleasePool.m
+    NXNumberInt.m
+    NXNumberUnsignedInt.m
     NXObject.m
     NXString.m
     NXTimeInterval.m

--- a/src/NXFoundation/NXApplication.m
+++ b/src/NXFoundation/NXApplication.m
@@ -70,7 +70,8 @@ static id sharedApplication = nil;
   // If there is no default zone, create one
   NXZone *zone = [NXZone defaultZone];
   if (zone == nil) {
-    zone = [NXZone zoneWithSize:0];
+    // Default zone size is set to 64KB
+    zone = [NXZone zoneWithSize:64 * 1024];
     if (zone == nil) {
       panicf("Failed to create default zone for NXApplication");
       return -1;

--- a/src/NXFoundation/NXNumberInt.h
+++ b/src/NXFoundation/NXNumberInt.h
@@ -1,0 +1,37 @@
+/**
+ * @file NXNumberInt.h
+ * @brief Defines the NXNumberInt class, which represents signed
+ * integer.
+ */
+#pragma once
+#include <NXFoundation/NXFoundation.h>
+
+/**
+ * @brief A class for managing and manipulating integer values.
+ */
+@interface NXNumberInt : NXObject {
+@private
+  int _value; ///< The integer value stored in this instance.
+}
+
+/**
+ * @brief Return an instance of an integer value.
+ * @param value The integer value to store in this instance.
+ * @return A newly initialized NXNumberInt instance, or nil if
+ * initialization failed.
+ */
++ (id)numberWithInt:(int)value;
+
+/**
+ * @brief Get the stored value as a signed integer.
+ * @return The integer value stored in this instance.
+ */
+- (int)intValue;
+
+/**
+ * @brief Get the stored value as an unsigned integer.
+ * @return The unsigned integer value stored in this instance.
+ */
+- (unsigned int)unsignedIntValue;
+
+@end

--- a/src/NXFoundation/NXNumberInt.m
+++ b/src/NXFoundation/NXNumberInt.m
@@ -1,0 +1,31 @@
+#include "NXNumberInt.h"
+#include <NXFoundation/NXFoundation.h>
+
+@implementation NXNumberInt
+
+/**
+ * @brief Return an instance of an integer value.
+ */
++ (id)numberWithInt:(int)value {
+  NXNumberInt *instance = [[self alloc] init];
+  if (instance) {
+    instance->_value = value; // Assuming _value is a private ivar of type int
+  }
+  return instance;
+}
+
+/**
+ * @brief Get the stored value as a signed integer.
+ */
+- (int)intValue {
+  return _value;
+}
+
+/**
+ * @brief Get the stored value as an unsigned integer.
+ */
+- (unsigned int)unsignedIntValue {
+  return (unsigned int)_value;
+}
+
+@end

--- a/src/NXFoundation/NXNumberInt.m
+++ b/src/NXFoundation/NXNumberInt.m
@@ -11,7 +11,7 @@
   if (instance) {
     instance->_value = value; // Assuming _value is a private ivar of type int
   }
-  return instance;
+  return [instance autorelease];
 }
 
 /**

--- a/src/NXFoundation/NXNumberUnsignedInt.h
+++ b/src/NXFoundation/NXNumberUnsignedInt.h
@@ -1,0 +1,46 @@
+/**
+ * @file NXNumberUnsignedInt.h
+ * @brief Defines the NXNumberUnsignedInt class, which represents unsigned
+ * integer and boolean values.
+ */
+#pragma once
+#include <NXFoundation/NXFoundation.h>
+
+/**
+ * @brief A class for managing and manipulating unsigned integer and boolean
+ * values.
+ */
+@interface NXNumberUnsignedInt : NXObject {
+@private
+  unsigned int _value; ///< The unsigned integer value stored in this instance.
+}
+
+/**
+ * @brief Return an instance of an unsigned integer value.
+ * @param value The unsigned integer value to store in this instance.
+ * @return A newly initialized NXNumberUnsignedInt instance, or nil if
+ * initialization failed.
+ */
++ (id)numberWithUnsignedInt:(unsigned int)value;
+
+/**
+ * @brief Return an instance of a boolean value.
+ * @param value The boolean value to store
+ * @return A newly initialized NXNumberUnsignedInt instance, or nil if
+ * initialization failed.
+ */
++ (id)numberWithBool:(BOOL)value;
+
+/**
+ * @brief Get the stored value as an unsigned integer.
+ * @return The unsigned integer value stored in this instance.
+ */
+- (unsigned int)unsignedIntValue;
+
+/**
+ * @brief Get the stored value as a boolean.
+ * @return YES if the stored value is non-zero, NO if it is zero.
+ */
+- (BOOL)boolValue;
+
+@end

--- a/src/NXFoundation/NXNumberUnsignedint.m
+++ b/src/NXFoundation/NXNumberUnsignedint.m
@@ -1,0 +1,61 @@
+#include "NXNumberUnsignedInt.h"
+#include <NXFoundation/NXFoundation.h>
+
+///////////////////////////////////////////////////////////////////////////////
+// TYPES
+
+// Re-usable static instances of NXNumberUnsignedInt for true, false
+static NXNumberUnsignedInt *trueNumber;
+static NXNumberUnsignedInt *falseNumber;
+
+///////////////////////////////////////////////////////////////////////////////
+// LIFECYCLE
+
+@implementation NXNumberUnsignedInt
+
++ (void)initialize {
+  // Initialize the static instances of NXNumberUnsignedInt
+  trueNumber = [NXNumberUnsignedInt numberWithBool:YES];
+  objc_assert(trueNumber);
+  falseNumber = [NXNumberUnsignedInt numberWithBool:NO];
+  objc_assert(falseNumber);
+}
+
+/**
+ * @brief Return an instance of an unsigned integer value.
+ */
++ (id)numberWithUnsignedInt:(unsigned int)value {
+  NXNumberUnsignedInt *instance = [[self alloc] init];
+  if (instance) {
+    instance->_value =
+        value; // Assuming _value is a private ivar of type unsigned int
+  }
+  return [instance autorelease];
+}
+
+/**
+ * @brief Return an instance of a boolean value.
+ */
++ (id)numberWithBool:(BOOL)value {
+  NXNumberUnsignedInt *instance = [[self alloc] init];
+  if (instance) {
+    instance->_value = value; // Store as unsigned int
+  }
+  return [instance autorelease];
+}
+
+/**
+ * @brief Get the stored value as an unsigned integer.
+ */
+- (unsigned int)unsignedIntValue {
+  return _value;
+}
+
+/**
+ * @brief Get the stored value as a boolean.
+ */
+- (BOOL)boolValue {
+  return _value ? YES : NO; // Non-zero values are considered YES
+}
+
+@end

--- a/src/NXFoundation/NXNumberUnsignedint.m
+++ b/src/NXFoundation/NXNumberUnsignedint.m
@@ -15,9 +15,9 @@ static NXNumberUnsignedInt *falseNumber;
 
 + (void)initialize {
   // Initialize the static instances of NXNumberUnsignedInt
-  trueNumber = [NXNumberUnsignedInt numberWithBool:YES];
+  trueNumber = [[NXNumberUnsignedInt numberWithBool:YES] retain];
   objc_assert(trueNumber);
-  falseNumber = [NXNumberUnsignedInt numberWithBool:NO];
+  falseNumber = [[NXNumberUnsignedInt numberWithBool:NO] retain];
   objc_assert(falseNumber);
 }
 

--- a/src/NXFoundation/NXObject.m
+++ b/src/NXFoundation/NXObject.m
@@ -2,7 +2,8 @@
 
 @implementation NXObject
 
-#pragma mark - Lifecycle
+///////////////////////////////////////////////////////////////////////////////
+// LIFECYCLE
 
 /**
  * @brief Allocates a new instance of object in the default memory zone.
@@ -29,10 +30,13 @@
 
 /**
  * @brief Deallocate the object, freeing its memory.
+ * @warning This method intentionally does NOT call [super dealloc] to prevent
+ * double-free.
  */
 - (void)dealloc {
-  // If this is an NXZone class, then we simply return
-  if (object_getClass(self) == [NXZone class]) {
+  // If this is an NXZone class, then we simply return, since the zone will
+  // handle deallocation.
+  if (object_isKindOfClass(self, [NXZone class])) {
     return;
   }
   if (!_zone) {
@@ -41,12 +45,11 @@
   if (_retain != 0) {
     panicf("[NXObject dealloc] called with retain count %d", _retain);
   }
-  if (self != _zone) {
-    [_zone free:self]; // Free the memory in the zone
-  }
+  [_zone free:self]; // Free the memory in the zone
 }
 
-#pragma mark - Instance methods
+///////////////////////////////////////////////////////////////////////////////
+// INSTANCE METHODS
 
 /**
  * @brief Increases the retain count of the receiver.

--- a/src/NXFoundation/NXObject.m
+++ b/src/NXFoundation/NXObject.m
@@ -45,7 +45,9 @@
   if (_retain != 0) {
     panicf("[NXObject dealloc] called with retain count %d", _retain);
   }
-  [_zone free:self]; // Free the memory in the zone
+  if (self != _zone) {
+    [_zone free:self]; // Free the memory in the zone
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/NXFoundation/NXObject.m
+++ b/src/NXFoundation/NXObject.m
@@ -31,6 +31,10 @@
  * @brief Deallocate the object, freeing its memory.
  */
 - (void)dealloc {
+  // If this is an NXZone class, then we simply return
+  if (object_getClass(self) == [NXZone class]) {
+    return;
+  }
   if (!_zone) {
     panicf("Object dealloc called without a zone");
   }

--- a/src/NXFoundation/NXString.m
+++ b/src/NXFoundation/NXString.m
@@ -1,81 +1,84 @@
-#include <NXFoundation/NXFoundation.h>
 #include "NXZone+malloc.h"
+#include <NXFoundation/NXFoundation.h>
 #include <string.h>
 
 @implementation NXString
 
-#pragma mark - Lifecycle
+///////////////////////////////////////////////////////////////////////////////
+// LIFECYCLE
 
 /**
  * @brief Initializes a new string by referencing another string.
  */
--(id) initWithString:(id)other {
-    self = [super init];
-    if (self == nil || self == other) {
-        return nil;
+- (id)initWithString:(id)other {
+  self = [super init];
+  if (self == nil || self == other) {
+    return nil;
+  }
+  _value = nil;
+  _alloc = NO;
+  if (other != nil) {
+    if ([other class] == [NXConstantString class]) {
+      _value = other;
+    } else if ([other isKindOfClass:[NXString class]]) {
+      _value = [other retain];
+    } else {
+      [self release];
+      return nil;
     }
-    _value = nil;
-    _alloc = NO;
-    if (other != nil) {
-        if ([other class] == [NXConstantString class]) {
-            _value = other;
-        } else if ([other isKindOfClass:[NXString class]]) {
-            _value = [other retain];
-        } else {
-            [self release];
-            return nil;
-        }
-    }
-    return self;
+  }
+  return self;
 }
 
 /**
  * @brief Initialize a new string by referencing a c-string.
  */
--(id) initWithCString:(const char* )cStr {
-    self = [super init];
-    if (self == nil) {
-        return nil;
-    }
-    _value = [[NXConstantString alloc] initWithCString:cStr];
-    _alloc = YES; // We need to de-allocate the constant string when de-allocating this NXString
-    return self;
+- (id)initWithCString:(const char *)cStr {
+  self = [super init];
+  if (self == nil) {
+    return nil;
+  }
+  _value = [[NXConstantString alloc] initWithCString:cStr];
+  _alloc = YES; // We need to de-allocate the constant string when de-allocating
+                // this NXString
+  return self;
 }
 
 /**
  * @brief Releases the string's internal value.
  */
--(void) dealloc {
-    if (_value != nil) {
-        if ([_value class] == [NXConstantString class] && _alloc) {
-            [_value release]; // Release the constant string if it was allocated
-        } else if ([_value isKindOfClass:[NXString class]]) {
-            [_value release];
-        }
+- (void)dealloc {
+  if (_value != nil) {
+    if ([_value class] == [NXConstantString class] && _alloc) {
+      [_value release]; // Release the constant string if it was allocated
+    } else if ([_value isKindOfClass:[NXString class]]) {
+      [_value release];
     }
-    [super dealloc];
+  }
+  [super dealloc];
 }
 
-#pragma mark - Methods
+///////////////////////////////////////////////////////////////////////////////
+// INSTANCE METHODS
 
 /**
  * @brief Returns the C-string representation of the string.
  */
-- (const char* )cStr {
-    if (_value != nil) {
-        return [_value cStr];
-    }
-    return NULL;
+- (const char *)cStr {
+  if (_value != nil) {
+    return [_value cStr];
+  }
+  return NULL;
 }
 
 /**
  * @brief Returns the length of the string.
  */
-- (unsigned int) length {
-    if (_value != nil) {
-        return [_value length];
-    }
-    return 0;
+- (unsigned int)length {
+  if (_value != nil) {
+    return [_value length];
+  }
+  return 0;
 }
 
 @end

--- a/src/NXFoundation/NXThread.m
+++ b/src/NXFoundation/NXThread.m
@@ -3,7 +3,8 @@
 
 @implementation NXThread
 
-#pragma mark - Class methods
+///////////////////////////////////////////////////////////////////////////////
+// CLASS METHODS
 
 + (void)sleepForTimeInterval:(NXTimeInterval)interval {
   if (interval < 0) {

--- a/src/NXFoundation/NXTimeInterval.m
+++ b/src/NXFoundation/NXTimeInterval.m
@@ -1,5 +1,8 @@
 #include <NXFoundation/NXFoundation.h>
 
+///////////////////////////////////////////////////////////////////////////////
+// TYPES
+
 /** @brief Base unit: 1 millisecond */
 const NXTimeInterval Millisecond = 1;
 

--- a/src/NXFoundation/NXZone+arena.c
+++ b/src/NXFoundation/NXZone+arena.c
@@ -162,8 +162,8 @@ static void *objc_arena_find_free_space(struct objc_arena *arena, size_t size) {
   uintptr_t search_end = arena_end - needed;
   uintptr_t aligned_search_end = (search_end / alignment) * alignment;
 
-  for (intptr_t pos = (intptr_t)aligned_search_end; pos >= (intptr_t)arena_start;
-       pos -= (intptr_t)alignment) {
+  for (intptr_t pos = (intptr_t)aligned_search_end;
+       pos >= (intptr_t)arena_start; pos -= (intptr_t)alignment) {
 
     // Check if this position would collide with any existing allocation
     if (objc_arena_check_collision(arena, (void *)pos, needed) == NO) {

--- a/src/NXFoundation/NXZone.m
+++ b/src/NXFoundation/NXZone.m
@@ -7,11 +7,11 @@ static id defaultZone = nil;
 
 @implementation NXZone
 
-#pragma mark - Lifecycle
+///////////////////////////////////////////////////////////////////////////////
+// LIFECYCLE
 
-/*
- ** Cannot use [[alloc] init] with NXZone.
- ** These methods are marked as unavailable to prevent misuse.
+/**
+ * @note Cannot use [[alloc] init] with NXZone.
  */
 + (id)alloc {
   return nil;
@@ -83,13 +83,15 @@ static id defaultZone = nil;
   [super dealloc];
 }
 
-#pragma mark - Class methods
+///////////////////////////////////////////////////////////////////////////////
+// CLASS METHODS
 
 + (id)defaultZone {
   return defaultZone;
 }
 
-#pragma mark - Instance methods
+///////////////////////////////////////////////////////////////////////////////
+// INSTANCE METHODS
 
 - (void *)allocWithSize:(size_t)size {
   void *ptr = NULL;

--- a/src/tests/NXFoundation_03/main.m
+++ b/src/tests/NXFoundation_03/main.m
@@ -1,5 +1,5 @@
-#include <tests/tests.h>
 #include <NXFoundation/NXFoundation.h>
+#include <tests/tests.h>
 
 @interface TestA : NXObject
 @end
@@ -14,51 +14,50 @@
 @end
 
 int main() {
-    // Create a zone
-    NXZone* zone = [NXZone zoneWithSize:0];
-    test_assert(zone != nil);
-    test_assert([NXZone defaultZone] == zone);
+  // Create a zone
+  NXZone *zone = [NXZone zoneWithSize:1024];
+  test_assert(zone != nil);
+  test_assert([NXZone defaultZone] == zone);
 
-    // NXObject
-    NXObject* object = [[NXObject alloc] init];
-    test_assert(object != nil);
-    test_assert([object class] != [TestA class]);
-    test_assert([object class] != [TestB class]);
-    test_assert([object class] == [NXObject class]);
-    test_assert([object isKindOfClass:[TestA class]] == NO);
-    test_assert([object isKindOfClass:[TestB class]] == NO);
-    test_assert([object isKindOfClass:[NXObject class]]);
-    test_assert([object isKindOfClass:[Object class]]);
-    [object release];
+  // NXObject
+  NXObject *object = [[NXObject alloc] init];
+  test_assert(object != nil);
+  test_assert([object class] != [TestA class]);
+  test_assert([object class] != [TestB class]);
+  test_assert([object class] == [NXObject class]);
+  test_assert([object isKindOfClass:[TestA class]] == NO);
+  test_assert([object isKindOfClass:[TestB class]] == NO);
+  test_assert([object isKindOfClass:[NXObject class]]);
+  test_assert([object isKindOfClass:[Object class]]);
+  [object release];
 
-    // TestA
-    TestA* testa = [[TestA alloc] init];
-    test_assert(testa != nil);
-    test_assert([testa class] == [TestA class]);
-    test_assert([testa class] != [TestB class]);
-    test_assert([testa isKindOfClass:[TestA class]]);
-    test_assert([object isKindOfClass:[TestB class]] == NO);
-    test_assert([testa isKindOfClass:[NXObject class]]);
-    test_assert([testa isKindOfClass:[Object class]]);
-    [testa release];
+  // TestA
+  TestA *testa = [[TestA alloc] init];
+  test_assert(testa != nil);
+  test_assert([testa class] == [TestA class]);
+  test_assert([testa class] != [TestB class]);
+  test_assert([testa isKindOfClass:[TestA class]]);
+  test_assert([object isKindOfClass:[TestB class]] == NO);
+  test_assert([testa isKindOfClass:[NXObject class]]);
+  test_assert([testa isKindOfClass:[Object class]]);
+  [testa release];
 
+  // TestB
+  TestB *testb = [[TestB alloc] init];
+  test_assert(testb != nil);
+  test_assert([testb class] != [TestA class]);
+  test_assert([testb class] == [TestB class]);
+  test_assert([testb isKindOfClass:[TestB class]]);
+  test_assert([testb isKindOfClass:[TestA class]]);
+  test_assert([testb isKindOfClass:[NXObject class]]);
+  test_assert([testb isKindOfClass:[Object class]]);
+  [testb release];
 
-    // TestB
-    TestB* testb = [[TestB alloc] init];
-    test_assert(testb != nil);
-    test_assert([testb class] != [TestA class]);
-    test_assert([testb class] == [TestB class]);
-    test_assert([testb isKindOfClass:[TestB class]]);
-    test_assert([testb isKindOfClass:[TestA class]]);
-    test_assert([testb isKindOfClass:[NXObject class]]);
-    test_assert([testb isKindOfClass:[Object class]]);
-    [testb release];
+  // Free the zone
+  // TODO: Use an autorelease pool to ensure proper memory management
+  [zone dealloc];
+  test_assert([NXZone defaultZone] == nil);
 
-    // Free the zone
-    // TODO: Use an autorelease pool to ensure proper memory management
-    [zone dealloc];
-    test_assert([NXZone defaultZone] == nil);
-
-    // Return success
-    return 0;
+  // Return success
+  return 0;
 }

--- a/src/tests/NXFoundation_04/main.m
+++ b/src/tests/NXFoundation_04/main.m
@@ -4,7 +4,7 @@
 
 int main() {
   // Create a zone
-  NXZone *zone = [NXZone zoneWithSize:0];
+  NXZone *zone = [NXZone zoneWithSize:1024];
   test_assert(zone != nil);
   test_assert([NXZone defaultZone] == zone);
 

--- a/src/tests/NXFoundation_05/main.m
+++ b/src/tests/NXFoundation_05/main.m
@@ -4,7 +4,7 @@
 
 int main() {
   // Memory management
-  NXZone *zone = [NXZone zoneWithSize:0];
+  NXZone *zone = [NXZone zoneWithSize:1024];
   NXAutoreleasePool *pool = [[NXAutoreleasePool alloc] init];
 
   // Create an object

--- a/src/tests/NXFoundation_06/main.m
+++ b/src/tests/NXFoundation_06/main.m
@@ -4,7 +4,7 @@
 
 int main() {
   // Create a zone, and autorelease pool
-  NXZone *zone = [NXZone zoneWithSize:0];
+  NXZone *zone = [NXZone zoneWithSize:1024 * 64];
   NXAutoreleasePool *pool = [[NXAutoreleasePool alloc] init];
   test_assert(pool != nil);
   test_assert([NXAutoreleasePool currentPool] == pool);


### PR DESCRIPTION
This PR updates tests to use non-zero zone sizes and introduces new number classes for the NXFoundation framework. The changes appear to be fixing an issue where zones were being created with zero size, which could cause problems in memory allocation.

* Updates all test files to use proper zone sizes instead of zero
* Adds new NXNumberInt and NXNumberUnsignedInt classes for number handling
* Includes special deallocation logic for NXZone objects
