### PR TITLE
Updated

### DIFF
--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Generate Documentation
         run: |
-          docker run -v.:/data greenbone/doxygen doxygen /data/doxygen/Doxyfile
+          make docs
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ tests: NXFoundation
 docs: dep-docker 
 	@echo
 	@echo make docs
-	@${DOCKER} run -v.:/data greenbone/doxygen doxygen /data/doxygen/Doxyfile
+	@${DOCKER} run -v .:/data greenbone/doxygen doxygen /data/doxygen/Doxyfile
 
 #.PHONY: test
 #test: submodule


### PR DESCRIPTION
This PR updates the documentation generation process in the GitHub Actions workflow to use a simpler build command instead of Docker.

Replaces Docker-based Doxygen command with a make docs command
Simplifies the documentation build process by leveraging a Makefile target