### PR TITLE
Added more tests

### DIFF
--- a/src/NXFoundation/NXString.m
+++ b/src/NXFoundation/NXString.m
@@ -37,7 +37,7 @@
   if (self == nil || self == other || other == nil) {
     return nil;
   }
-  if ([other class] == [NXConstantString class]) {
+  if (object_getClass(other) == objc_lookupClass("NXConstantString")) {
     _value = [other cStr];
     _length = [other length];
   } else if ([other isKindOfClass:[NXString class]]) {

--- a/src/runtime-gcc/Protocol.m
+++ b/src/runtime-gcc/Protocol.m
@@ -11,6 +11,14 @@
 }
 
 /**
+ * @brief Returns the class name of the protocol.
+ * @return A C string containing the protocol class name.
+ */
++ (const char *)name {
+  return "Protocol";
+}
+
+/**
  * @brief Checks if this protocol conforms to another protocol.
  */
 - (BOOL)conformsTo:(Protocol *)aProtocolObject {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -51,6 +51,12 @@ add_subdirectory(runtime_28)
 add_subdirectory(runtime_29)
 add_subdirectory(runtime_30)
 add_subdirectory(runtime_31)
+add_subdirectory(runtime_32)
+add_subdirectory(runtime_33)
+add_subdirectory(runtime_34)
+add_subdirectory(runtime_35)
+add_subdirectory(runtime_36)
+add_subdirectory(runtime_37)
 
 # Test cases - NXFoundation
 add_subdirectory(NXFoundation_01)

--- a/src/tests/runtime_32/CMakeLists.txt
+++ b/src/tests/runtime_32/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(NAME "runtime_32")
+add_executable(${NAME}
+    main.m
+)
+target_link_libraries(${NAME} PRIVATE
+    objc-gcc
+    malloc
+)
+add_test(NAME ${NAME} COMMAND ${NAME})

--- a/src/tests/runtime_32/main.m
+++ b/src/tests/runtime_32/main.m
@@ -1,0 +1,22 @@
+#include <objc/objc.h>
+#include <runtime-sys/sys.h>
+#include <tests/tests.h>
+
+int test_runtime_32(void);
+
+int main(void) { return TestMain("test_runtime_32", test_runtime_32); }
+
+@protocol Foo
+- (void)foo;
+@end
+
+int test_runtime_32(void) {
+  Protocol *protocol = @protocol(Foo);
+  test_assert(protocol != nil);
+  test_assert(proto_getName((objc_protocol_t *)protocol) != NULL);
+  test_cstrings_equal(proto_getName((objc_protocol_t *)protocol), "Foo");
+  test_cstrings_equal(proto_getName((objc_protocol_t *)@protocol(Foo)), "Foo");
+  test_cstrings_equal([Protocol name], "Protocol");
+  test_assert([protocol isEqual:protocol]);
+  return 0;
+}

--- a/src/tests/runtime_33/CMakeLists.txt
+++ b/src/tests/runtime_33/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(NAME "runtime_33")
+add_executable(${NAME}
+    main.m
+)
+target_link_libraries(${NAME} PRIVATE
+    objc-gcc
+    malloc
+)
+add_test(NAME ${NAME} COMMAND ${NAME})

--- a/src/tests/runtime_33/main.m
+++ b/src/tests/runtime_33/main.m
@@ -1,0 +1,33 @@
+#include <objc/objc.h>
+#include <runtime-sys/sys.h>
+#include <tests/tests.h>
+
+int test_runtime_33(void);
+
+int main(void) { return TestMain("test_runtime_33", test_runtime_33); }
+
+@protocol Foo1
+- (void)foo1;
+@end
+
+@protocol Foo2
+- (void)foo2;
+@end
+
+int test_runtime_33(void) {
+  test_assert(@protocol(Foo1) != @protocol(Foo2));
+  test_assert([@protocol(Foo1) isEqual:@protocol(Foo1)] == YES);
+  test_assert([@protocol(Foo1) isEqual:@protocol(Foo2)] == NO);
+  test_assert([@protocol(Foo2) isEqual:@protocol(Foo2)] == YES);
+  test_assert([@protocol(Foo1) isEqual:nil] == NO);
+  test_assert([@protocol(Foo2) isEqual:nil] == NO);
+
+  Class protocol = objc_lookupClass("Protocol");
+  Class object = objc_lookupClass("Object");
+  test_assert(protocol != nil);
+  test_assert(object != nil);
+  test_assert(class_getSuperclass(protocol) == object);
+  test_cstrings_equal(class_getName(protocol), "Protocol");
+
+  return 0;
+}

--- a/src/tests/runtime_34/CMakeLists.txt
+++ b/src/tests/runtime_34/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(NAME "runtime_34")
+add_executable(${NAME}
+    main.m
+)
+target_link_libraries(${NAME} PRIVATE
+    objc-gcc
+    malloc
+)
+add_test(NAME ${NAME} COMMAND ${NAME})

--- a/src/tests/runtime_34/main.m
+++ b/src/tests/runtime_34/main.m
@@ -1,0 +1,44 @@
+#include <objc/objc.h>
+#include <runtime-sys/sys.h>
+#include <stdarg.h>
+#include <tests/tests.h>
+
+int test_runtime_34(void);
+
+int main(void) { return TestMain("test_runtime_34", test_runtime_34); }
+
+/* Test method with variable number of arguments */
+
+@interface MathClass : Object
+
+/* sum positive numbers; -1 ends the list */
++ (int)sum:(int)firstNumber, ...;
+
+@end
+
+@implementation MathClass
+
++ (int)sum:(int)firstNumber, ... {
+  va_list ap;
+  va_start(ap, firstNumber);
+
+  int sum = 0;
+  int number = firstNumber;
+  while (number >= 0) {
+    sum += number;
+    number = va_arg(ap, int);
+  }
+
+  va_end(ap);
+  return sum;
+}
+
+@end
+
+int test_runtime_34(void) {
+  test_assert(([MathClass sum:1, 2, 3, 4, 5, -1] == 15));
+  test_assert(([MathClass sum:10, 20, 30, -1] == 60));
+  test_assert(([MathClass sum:0, -1] == 0));
+  test_assert(([MathClass sum:-1] == 0));
+  return 0;
+}

--- a/src/tests/runtime_35/CMakeLists.txt
+++ b/src/tests/runtime_35/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(NAME "runtime_35")
+add_executable(${NAME}
+    main.m
+)
+target_link_libraries(${NAME} PRIVATE
+    objc-gcc
+    malloc
+)
+add_test(NAME ${NAME} COMMAND ${NAME})

--- a/src/tests/runtime_35/main.m
+++ b/src/tests/runtime_35/main.m
@@ -1,0 +1,32 @@
+#include <objc/objc.h>
+#include <runtime-sys/sys.h>
+#include <stdarg.h>
+#include <tests/tests.h>
+
+int test_runtime_35(void);
+
+int main(void) { return TestMain("test_runtime_35", test_runtime_35); }
+
+/* Test defining a static variable *inside* a class implementation */
+
+@interface Test : Object
++ (int)test;
+@end
+
+@implementation Test
+
+static int test = 1;
+
++ (int)test {
+  return test;
+}
+
++ initialize {
+  return self;
+}
+@end
+
+int test_runtime_35(void) {
+  test_assert([Test test] == 1);
+  return 0;
+}

--- a/src/tests/runtime_36/CMakeLists.txt
+++ b/src/tests/runtime_36/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(NAME "runtime_36")
+add_executable(${NAME}
+    main.m
+)
+target_link_libraries(${NAME} PRIVATE
+    objc-gcc
+    malloc
+)
+add_test(NAME ${NAME} COMMAND ${NAME})

--- a/src/tests/runtime_36/main.m
+++ b/src/tests/runtime_36/main.m
@@ -1,0 +1,32 @@
+#include <objc/objc.h>
+#include <runtime-sys/sys.h>
+#include <stdarg.h>
+#include <tests/tests.h>
+
+int test_runtime_36(void);
+
+int main(void) { return TestMain("test_runtime_36", test_runtime_36); }
+
+/* Test defining a static function *inside* a class implementation */
+
+@interface Test : Object
++ (int)test;
+@end
+
+@implementation Test
+
+static int test(void) { return 1; }
+
++ (int)test {
+  return test();
+}
+
++ initialize {
+  return self;
+}
+@end
+
+int test_runtime_36(void) {
+  test_assert([Test test] == 1);
+  return 0;
+}

--- a/src/tests/runtime_37/CMakeLists.txt
+++ b/src/tests/runtime_37/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(NAME "runtime_37")
+add_executable(${NAME}
+    main.m
+)
+target_link_libraries(${NAME} PRIVATE
+    objc-gcc
+    malloc
+)
+add_test(NAME ${NAME} COMMAND ${NAME})

--- a/src/tests/runtime_37/main.m
+++ b/src/tests/runtime_37/main.m
@@ -1,0 +1,15 @@
+#include <objc/objc.h>
+#include <runtime-sys/sys.h>
+#include <stdarg.h>
+#include <tests/tests.h>
+
+int test_runtime_37(void);
+
+int main(void) { return TestMain("test_runtime_37", test_runtime_37); }
+
+int test_runtime_37(void) {
+  SEL selector = @selector(alloc);
+  const char *selname = sel_getName(selector);
+  test_cstrings_equal(selname, "alloc");
+  return 0;
+}


### PR DESCRIPTION
This pull request adds six new runtime test cases (runtime_32 through runtime_37) to validate various Objective-C runtime features. The tests cover protocol handling, variadic methods, static variables/functions within class implementations, and selector name retrieval.

Adds comprehensive test coverage for protocol operations and metadata
Implements tests for variadic methods and static declarations within class implementations
Includes a selector name retrieval test and updates Protocol class to support new functionality