### PR TITLE
djt-0726-nxdata-fix

### DIFF
--- a/src/tests/NXFoundation_20/main.m
+++ b/src/tests/NXFoundation_20/main.m
@@ -343,13 +343,13 @@ int test_json_methods(void) {
   [singleData release];
   printf("✓ Single byte NXData JSON serialization\n");
 
-  // Test string data (with null terminator)
+  // Test string data (without null terminator)
   NXData *stringData = [[NXData alloc] initWithString:@"Test"];
   test_assert([stringData JSONBytes] ==
-              9); // "VGVzdAA=" (8 chars + null terminator)
+              9); // "VGVzdA==" (8 chars + null terminator)
   NXString *stringJson = [stringData JSONString];
   test_assert(stringJson != nil);
-  test_cstrings_equal([stringJson cStr], "VGVzdAA="); // "Test\0" in Base64
+  test_cstrings_equal([stringJson cStr], "VGVzdA=="); // "Test" in Base64
   [stringData release];
   printf("✓ String-based NXData JSON serialization\n");
 

--- a/src/tests/README.md
+++ b/src/tests/README.md
@@ -39,7 +39,7 @@ The tests are organized into three main categories:
 | NXFoundation_19 | Number Comprehensive Testing | Comprehensive NXNumber tests: all types, conversions, edge cases, memory management. |
 | NXFoundation_20 | JSON Protocol Testing | Tests JSONProtocol conformance for NXString, NXNumber, NXNull, NXDate, and NXData with Base64 serialization. |
 | NXFoundation_21 | Array Testing | Tests NXArray functionality: creation, access, JSON serialization, mutable operations, and edge cases. |
-| NXFoundation_22 | Data Operations | Tests NXData binary data storage: initialization, memory management, hexString/base64String encoding, and cross-format consistency. |
+| NXFoundation_22 | Data Operations | Tests NXData binary data storage: initialization, memory management, hexString/base64String encoding, append operations (appendString/appendBytes/appendData), capacity expansion, and cross-format consistency. |
 
 ---
 


### PR DESCRIPTION
This PR fixes the handling of string data in NXData to exclude null terminators, consistent with typical binary data handling conventions. The change ensures that when strings are stored in NXData objects, only the actual string content is preserved without the C-style null terminator.

Modified NXData string initialization to exclude null terminators
Added comprehensive append functionality (appendString, appendBytes, appendData) with automatic capacity expansion
Updated all tests to reflect the new null-terminator-free behavior