### PR TITLE
Added hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You will minimally need the following tools to build the runtime:
 
 - **Build system** `make` and `cmake` - for the build system
 - **Compiler** `clang` or `gcc` - for compiling the runtime (`clang` is not supported on Apple Silicon). You can use the environment variable `CC` to specify the compiler, e.g. `CC=clang` or `CC=gcc`.
+- **Library Dependencies** `openssl` for Linux and Darwin - for the hash functions, which are used in the runtime and NXFoundation framework.
 - **Documentation** `docker` is needed for generating the documentation from the source code.
 - **Cross-Compilation** For cross-compilation for embedded systems based on some ARM variant, get the ARM LLVM toolchain: <https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases>. Install this to the `/opt` directory. You can use the environment variable `TOOLCHAIN_PATH` to specify the path to the toolchain, e.g. `TOOLCHAIN_PATH=/opt/LLVM-ET-Arm-19.1.5-Darwin-universal`.
 
@@ -21,7 +22,7 @@ Three static libraries are currently built:
 
 - `objc-gcc` - the Objective C runtime library using the ancient GCC ABI
 - `NXFoundation` - a minimal set of classes, to support memory management and basic types such as string, array, dictionary, date, time and number.
-- `runtime-sys` - a minimal set of system functions, needed to bind the runtime to the underlying system, on a per-platform basis.
+- `runtime-sys` - a minimal set of system functions, needed to bind the runtime to the underlying system, on a per-platform basis. Includes cryptographic hash functions (MD5, SHA-256).
 
 Download the source code from GitHub:
 
@@ -101,13 +102,14 @@ The documentation is also published [here](https://djthorpe.github.io/objc/).
 - [X] Fix linking categories in static libraries (see test NXFoundation_05)
 - [X] `NXString` - mutable strings - append, appendFormat
 - [X] `NXArray` - ordered collections of objects, with methods for adding, removing, and accessing objects
+- [X] `NXData` - mutable binary data with Base64/hex encoding and append operations
+- [X] Hash functions - MD5 and SHA-256 hash computation through `sys_hash_*` API
 - [ ] `NXString` - array methods - split, join, etc.
 - [ ] printf - `%@` format specifier for logging objects and `[Object description]`
 - [ ] printf - `%f and %lf` format specifier for floats and doubles
 - [ ] printf - `%T` format specifier for time intervals
 - [ ] Number - `NXNumber` with `NXNumberFloat` and `NXNumberDouble`
 - [ ] `NXMap` - unordered collections with string-keys (what about `NXDictionary`?)
-- [ ] `NXData` - mutable data creating hashes
 - [ ] `make install` will compile the libraries and install them to a prefix path
 - [ ] clang compatibility (probably fix with selectors)
 - [ ] `respondsToSelector:` (see test `runtime_14`)

--- a/docker/Dockerfile.bookworm
+++ b/docker/Dockerfile.bookworm
@@ -5,7 +5,7 @@
 #   docker buildx build -f docker/Dockerfile.bookworm --build-arg PLATFORM=arm64 --tag bookworm-builder .
 #   docker buildx build -f docker/Dockerfile.bookworm --build-arg PLATFORM=x86_64 --tag bookworm-builder .
 #
-# RUN TESTS (clang/gcc):
+# RUN TESTS (gcc/clang):
 #   docker run --rm -i -v $(pwd):/root bookworm-builder bash -c "cd /root && make clean && CC=gcc make tests"
 #   docker run --rm -i -v $(pwd):/root bookworm-builder bash -c "cd /root && make clean && CC=clang make tests"
 #
@@ -14,5 +14,5 @@ FROM --platform=$PLATFORM debian:bookworm
 
 # Install build dependencies
 RUN apt update && apt upgrade -y && \
-    apt install -y --no-install-recommends build-essential cmake git clang gobjc
+    apt install -y --no-install-recommends build-essential cmake git clang gobjc libssl-dev
 

--- a/include/runtime-sys/hash.h
+++ b/include/runtime-sys/hash.h
@@ -1,0 +1,87 @@
+/**
+ * @file hash.h
+ * @brief Defines the ability to create hashes from data.
+ *
+ * This file declares various system methods for hash generation using OpenSSL.
+ * Supports MD5 and SHA-256 algorithms with a simple, consistent API.
+ *
+ * Usage example:
+ * @code
+ * sys_hash_t hash = sys_hash_init(sys_hash_sha256);
+ * sys_hash_update(&hash, "hello", 5);
+ * sys_hash_update(&hash, "world", 5);
+ * const uint8_t *result = sys_hash_finalize(&hash);
+ * @endcode
+ */
+#pragma once
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @brief Hash algorithm identifiers.
+ *
+ * Enumeration of supported cryptographic hash algorithms.
+ */
+typedef enum {
+  sys_hash_md5,    // MD5 hash (128-bit)
+  sys_hash_sha256, // SHA-256 hash (256-bit)
+} sys_hash_algorithm_t;
+
+/**
+ * @brief Hash context structure.
+ *
+ * Contains the state and result buffer for hash operations.
+ */
+typedef struct {
+  uint8_t hash[32]; // Buffer to hold the hash value = max is SHA-256 (32 bytes)
+  size_t size;      // Size of the hash in bytes
+  void *ctx;        // Any context needed for the hash operation
+} sys_hash_t;
+
+/**
+ * @brief Initializes a new hash context for the specified algorithm.
+ * @param algorithm The hash algorithm to use.
+ * @return A new sys_hash_t instance initialized for the specified algorithm.
+ *
+ * This function returns a sys_hash_t instance for the
+ * specified hash algorithm, ready for use in hashing operations. You must
+ * call sys_hash_final() to finalize the hash computation, even on failure
+ * of sys_hash_update().
+ *
+ * @note If a specific algorithm is not supported, the context will be
+ * initialized with size 0. You should check sys_hash_size() to verify if
+ * the context is usable.
+ */
+extern sys_hash_t sys_hash_init(sys_hash_algorithm_t algorithm);
+
+/**
+ * @brief Returns the size of the hash in bytes.
+ * @param hash The hash context to query.
+ * @return The size of the hash in bytes.
+ *
+ * This function returns the size of the hash value stored
+ * in the sys_hash_t instance, which is determined by the algorithm used.
+ * If the hashing failed, the size will be 0.
+ */
+extern size_t sys_hash_size(sys_hash_t *hash);
+
+/**
+ * @brief Updates the hash context with new data.
+ * @param hash The hash context to update.
+ * @param data The data to add to the hash.
+ * @param size The size of the data in bytes.
+ * @return true on success, false on failure.
+ */
+extern bool sys_hash_update(sys_hash_t *hash, const void *data, size_t size);
+
+/**
+ * @brief Finalizes the hash computation and returns the hash value.
+ * @param hash The hash context to finalize.
+ * @return A pointer to the computed hash value, or NULL on failure.
+ *
+ * This function finalizes the hash computation and returns
+ * a pointer to the computed hash value stored in the sys_hash_t instance.
+ * The context is automatically cleaned up after finalization.
+ */
+extern const uint8_t *sys_hash_finalize(sys_hash_t *hash);

--- a/include/runtime-sys/sys.h
+++ b/include/runtime-sys/sys.h
@@ -6,6 +6,7 @@
  * and resources.
  */
 #pragma once
+#include "hash.h"
 #include "malloc.h"
 #include "printf.h"
 #include "random.h"

--- a/src/runtime-sys/darwin/CMakeLists.txt
+++ b/src/runtime-sys/darwin/CMakeLists.txt
@@ -1,10 +1,14 @@
 set(NAME "runtime-sys")
 
+# Find OpenSSL
+find_package(OpenSSL REQUIRED)
+
 add_library(${NAME} STATIC
     abort.c
     exception.c
     mutex.c
     sys.c
+    ../openssl/hash.c
     ../posix/malloc.c
     ../posix/puts.c
     ../posix/random.c
@@ -18,4 +22,9 @@ add_library(${NAME} STATIC
 target_include_directories(${NAME} PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/../../../include
     ${CMAKE_CURRENT_LIST_DIR}/../../../include/runtime-${RUNTIME}
+    ${TOOLCHAIN_PATH}/include
+)
+target_link_libraries(${NAME} PRIVATE
+    OpenSSL::SSL
+    OpenSSL::Crypto
 )

--- a/src/runtime-sys/linux/CMakeLists.txt
+++ b/src/runtime-sys/linux/CMakeLists.txt
@@ -1,10 +1,14 @@
 set(NAME "runtime-sys")
 
+# Find OpenSSL
+find_package(OpenSSL REQUIRED)
+
 add_library(${NAME} STATIC
     abort.c
     exception.c
     mutex.c
     sys.c
+    ../openssl/hash.c
     ../posix/malloc.c
     ../posix/puts.c
     ../posix/random.c
@@ -18,4 +22,9 @@ add_library(${NAME} STATIC
 target_include_directories(${NAME} PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/../../../include
     ${CMAKE_CURRENT_LIST_DIR}/../../../include/runtime-${RUNTIME}
+    ${TOOLCHAIN_PATH}/include
+)
+target_link_libraries(${NAME} PRIVATE
+    OpenSSL::SSL
+    OpenSSL::Crypto
 )

--- a/src/runtime-sys/openssl/hash.c
+++ b/src/runtime-sys/openssl/hash.c
@@ -1,0 +1,84 @@
+/**
+ * @file hash.c
+ * @brief Implements hash generation functionality using OpenSSL.
+ *
+ * This file implements various system methods for hash generation.
+ */
+#include <openssl/evp.h>
+#include <runtime-sys/hash.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @brief Initializes a new hash context for the specified algorithm.
+ */
+sys_hash_t sys_hash_init(sys_hash_algorithm_t algorithm) {
+  sys_hash_t hash;
+  hash.size = 0;
+  hash.ctx = EVP_MD_CTX_new();
+
+  if (hash.ctx == NULL) {
+    // Failed to allocate context
+    return hash;
+  }
+
+  switch (algorithm) {
+  case sys_hash_md5:
+    if (EVP_DigestInit_ex(hash.ctx, EVP_md5(), NULL)) {
+      hash.size = 16; // MD5 produces a 128-bit hash
+    }
+    break;
+  case sys_hash_sha256:
+    if (EVP_DigestInit_ex(hash.ctx, EVP_sha256(), NULL)) {
+      hash.size = 32; // SHA-256 produces a 256-bit hash
+    }
+    break;
+  }
+
+  // If initialization failed, clean up and reset
+  if (hash.size == 0) {
+    EVP_MD_CTX_free(hash.ctx);
+    hash.ctx = NULL;
+  }
+
+  // Return the initialized hash context
+  return hash;
+}
+
+/**
+ * @brief Returns the size of the hash in bytes.
+ */
+size_t sys_hash_size(sys_hash_t *hash) {
+  if (hash) {
+    return hash->size;
+  }
+  return 0; // Handle error case
+}
+
+/**
+ * @brief Updates the hash context with new data.
+ */
+bool sys_hash_update(sys_hash_t *hash, const void *data, size_t size) {
+  if (data == NULL || hash == NULL || hash->ctx == NULL) {
+    return false;
+  }
+  if (size == 0) {
+    return true; // No data to update, consider it a success
+  }
+  return EVP_DigestUpdate(hash->ctx, data, size) ? true : false;
+}
+
+/**
+ * @brief Finalizes the hash computation and returns the hash value.
+ */
+const uint8_t *sys_hash_finalize(sys_hash_t *hash) {
+  bool result = false;
+  if (hash && hash->ctx) {
+    result = EVP_DigestFinal_ex(hash->ctx, hash->hash, NULL) ? true : false;
+    EVP_MD_CTX_free(hash->ctx); // Clean up the context
+    hash->ctx = NULL;
+    // Don't reset size - leave it so caller knows the hash length
+  }
+  return result ? hash->hash : NULL;
+}

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(sys_01)
 add_subdirectory(sys_02)
 add_subdirectory(sys_03)
 add_subdirectory(sys_04)
+add_subdirectory(sys_05)
 
 # Test cases - runtime
 add_subdirectory(runtime_01)

--- a/src/tests/README.md
+++ b/src/tests/README.md
@@ -10,7 +10,7 @@ The tests are organized into three main categories:
 
 - **NXFoundation Tests** (NXFoundation_01 through NXFoundation_22): Tests for the NXFoundation framework classes and functionality.
 - **Runtime Tests** (runtime_01 through runtime_37, excluding runtime_07): Tests for the Objective-C runtime system functionality.
-- **System Tests** (sys_01, sys_02, sys_03, sys_04): Tests for low-level system functionality.
+- **System Tests** (sys_01, sys_02, sys_03, sys_04, sys_05): Tests for low-level system functionality.
 
 ---
 
@@ -94,3 +94,4 @@ The tests are organized into three main categories:
 | sys_02 | Time System Functions | Tests `sys_time_get_utc()` with validation, NULL handling, and consistency. |
 | sys_03 | Thread System Functions | Tests `sys_thread_numcores()` with validation, consistency, and boundary testing. |
 | sys_04 | Random Number Generation | Tests `sys_random_uint32()` and `sys_random_uint64()` with validation and distribution testing. |
+| sys_05 | Hash Function Testing | Tests `sys_hash_*` functions with MD5/SHA-256 algorithms: initialization, known test vectors, multi-part updates, error handling, and cleanup behavior. |

--- a/src/tests/sys_05/CMakeLists.txt
+++ b/src/tests/sys_05/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(NAME "sys_05")
+add_executable(${NAME}
+    main.c
+)
+target_link_libraries(${NAME} PRIVATE
+    runtime-sys
+)
+add_test(NAME ${NAME} COMMAND ${NAME})
+
+# additional configurations for the Pico SDK
+if(CMAKE_SYSTEM_NAME STREQUAL "Pico")
+pico_add_extra_outputs(${NAME})
+pico_enable_stdio_usb(${NAME} 1)
+pico_enable_stdio_uart(${NAME} 0)
+endif()

--- a/src/tests/sys_05/main.c
+++ b/src/tests/sys_05/main.c
@@ -1,0 +1,243 @@
+#include <runtime-sys/hash.h>
+#include <runtime-sys/sys.h>
+#include <stdio.h>
+#include <string.h>
+#include <tests/tests.h>
+
+// Forward declaration
+int test_sys_05(void);
+
+int main(void) {
+  // Run hash function tests
+  return TestMain("test_sys_05", test_sys_05);
+}
+
+int test_sys_05(void) {
+  printf("Test 1: Hash initialization - MD5\n");
+  {
+    sys_hash_t hash = sys_hash_init(sys_hash_md5);
+    test_assert(sys_hash_size(&hash) == 16); // MD5 is 128 bits = 16 bytes
+    // Cleanup is handled by sys_hash_finalize, but we need to call it to clean
+    // up
+    sys_hash_finalize(&hash);
+    printf("  ✓ MD5 initialization works\n");
+  }
+
+  printf("Test 2: Hash initialization - SHA256\n");
+  {
+    sys_hash_t hash = sys_hash_init(sys_hash_sha256);
+    test_assert(sys_hash_size(&hash) == 32); // SHA-256 is 256 bits = 32 bytes
+    // Cleanup is handled by sys_hash_finalize, but we need to call it to clean
+    // up
+    sys_hash_finalize(&hash);
+    printf("  ✓ SHA-256 initialization works\n");
+  }
+
+  printf("Test 3: MD5 hash of empty string\n");
+  {
+    sys_hash_t hash = sys_hash_init(sys_hash_md5);
+    const uint8_t *result = sys_hash_finalize(&hash);
+    test_assert(result != NULL);
+
+    // MD5 of empty string: d41d8cd98f00b204e9800998ecf8427e
+    uint8_t expected[] = {0xd4, 0x1d, 0x8c, 0xd9, 0x8f, 0x00, 0xb2, 0x04,
+                          0xe9, 0x80, 0x09, 0x98, 0xec, 0xf8, 0x42, 0x7e};
+    test_assert(memcmp(result, expected, 16) == 0);
+    printf("  ✓ MD5 empty string hash correct\n");
+  }
+
+  printf("Test 4: SHA-256 hash of empty string\n");
+  {
+    sys_hash_t hash = sys_hash_init(sys_hash_sha256);
+    const uint8_t *result = sys_hash_finalize(&hash);
+    test_assert(result != NULL);
+
+    // SHA-256 of empty string:
+    // e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    uint8_t expected[] = {0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14,
+                          0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24,
+                          0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c,
+                          0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55};
+    test_assert(memcmp(result, expected, 32) == 0);
+    printf("  ✓ SHA-256 empty string hash correct\n");
+  }
+
+  printf("Test 5: MD5 hash of 'abc'\n");
+  {
+    sys_hash_t hash = sys_hash_init(sys_hash_md5);
+    const char *input = "abc";
+    test_assert(sys_hash_update(&hash, input, strlen(input)) == true);
+    const uint8_t *result = sys_hash_finalize(&hash);
+    test_assert(result != NULL);
+
+    // MD5 of "abc": 900150983cd24fb0d6963f7d28e17f72
+    uint8_t expected[] = {0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0,
+                          0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72};
+    test_assert(memcmp(result, expected, 16) == 0);
+    printf("  ✓ MD5 'abc' hash correct\n");
+  }
+
+  printf("Test 6: SHA-256 hash of 'abc'\n");
+  {
+    sys_hash_t hash = sys_hash_init(sys_hash_sha256);
+    const char *input = "abc";
+    test_assert(sys_hash_update(&hash, input, strlen(input)) == true);
+    const uint8_t *result = sys_hash_finalize(&hash);
+    test_assert(result != NULL);
+
+    // SHA-256 of "abc":
+    // ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+    uint8_t expected[] = {0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea,
+                          0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
+                          0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
+                          0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad};
+    test_assert(memcmp(result, expected, 32) == 0);
+    printf("  ✓ SHA-256 'abc' hash correct\n");
+  }
+
+  printf("Test 7: Multiple updates - MD5\n");
+  {
+    sys_hash_t hash = sys_hash_init(sys_hash_md5);
+
+    // Hash "abc" in multiple parts: "a" + "b" + "c"
+    test_assert(sys_hash_update(&hash, "a", 1) == true);
+    test_assert(sys_hash_update(&hash, "b", 1) == true);
+    test_assert(sys_hash_update(&hash, "c", 1) == true);
+
+    const uint8_t *result = sys_hash_finalize(&hash);
+    test_assert(result != NULL);
+
+    // Should be same as MD5 of "abc"
+    uint8_t expected[] = {0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0,
+                          0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72};
+    test_assert(memcmp(result, expected, 16) == 0);
+    printf("  ✓ Multiple updates work correctly\n");
+  }
+
+  printf("Test 8: Large data hashing - SHA-256\n");
+  {
+    sys_hash_t hash = sys_hash_init(sys_hash_sha256);
+
+    // Create 1000 'A' characters
+    char large_data[1001];
+    memset(large_data, 'A', 1000);
+    large_data[1000] = '\0';
+
+    test_assert(sys_hash_update(&hash, large_data, 1000) == true);
+    const uint8_t *result = sys_hash_finalize(&hash);
+    test_assert(result != NULL);
+    test_assert(sys_hash_size(&hash) == 32);
+    printf("  ✓ Large data hashing works\n");
+  }
+
+  printf("Test 9: Binary data hashing\n");
+  {
+    sys_hash_t hash = sys_hash_init(sys_hash_sha256);
+
+    // Create binary data with all byte values
+    uint8_t binary_data[256];
+    for (int i = 0; i < 256; i++) {
+      binary_data[i] = (uint8_t)i;
+    }
+
+    test_assert(sys_hash_update(&hash, binary_data, 256) == true);
+    const uint8_t *result = sys_hash_finalize(&hash);
+    test_assert(result != NULL);
+    printf("  ✓ Binary data hashing works\n");
+  }
+
+  printf("Test 10: Error handling - NULL data\n");
+  {
+    sys_hash_t hash = sys_hash_init(sys_hash_md5);
+
+    // Test with NULL data
+    test_assert(sys_hash_update(&hash, NULL, 10) == false);
+
+    // Test with zero size (should succeed)
+    test_assert(sys_hash_update(&hash, "test", 0) == true);
+
+    // Cleanup context
+    sys_hash_finalize(&hash);
+    printf("  ✓ NULL data handling works\n");
+  }
+
+  printf("Test 11: Error handling - invalid context\n");
+  {
+    sys_hash_t hash = {0}; // Uninitialized hash
+
+    // Should fail with uninitialized context
+    test_assert(sys_hash_update(&hash, "test", 4) == false);
+    test_assert(sys_hash_finalize(&hash) == NULL);
+    test_assert(sys_hash_size(&hash) == 0);
+    printf("  ✓ Invalid context handling works\n");
+  }
+
+  printf("Test 12: Hash size after finalization\n");
+  {
+    sys_hash_t hash = sys_hash_init(sys_hash_sha256);
+    test_assert(sys_hash_update(&hash, "test", 4) == true);
+
+    // Size should be available before finalization
+    test_assert(sys_hash_size(&hash) == 32);
+
+    const uint8_t *result = sys_hash_finalize(&hash);
+    test_assert(result != NULL);
+
+    // Size should still be available after finalization
+    test_assert(sys_hash_size(&hash) == 32);
+    printf("  ✓ Hash size persistence works\n");
+  }
+
+  printf("Test 13: Finalization behavior\n");
+  {
+    sys_hash_t hash = sys_hash_init(sys_hash_md5);
+    test_assert(sys_hash_update(&hash, "partial", 7) == true);
+
+    // Finalize the hash
+    const uint8_t *result = sys_hash_finalize(&hash);
+    test_assert(result != NULL);
+
+    // Context should be unusable after finalization
+    test_assert(sys_hash_update(&hash, "more", 4) == false);
+    test_assert(sys_hash_finalize(&hash) == NULL);
+    printf("  ✓ Cleanup without finalization works\n");
+  }
+
+  printf("Test 14: Known test vectors - SHA-256\n");
+  {
+    // Test with NIST test vector:
+    // "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+    sys_hash_t hash = sys_hash_init(sys_hash_sha256);
+    const char *input =
+        "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+    test_assert(sys_hash_update(&hash, input, strlen(input)) == true);
+    const uint8_t *result = sys_hash_finalize(&hash);
+    test_assert(result != NULL);
+
+    // Expected SHA-256:
+    // 248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1
+    uint8_t expected[] = {0x24, 0x8d, 0x6a, 0x61, 0xd2, 0x06, 0x38, 0xb8,
+                          0xe5, 0xc0, 0x26, 0x93, 0x0c, 0x3e, 0x60, 0x39,
+                          0xa3, 0x3c, 0xe4, 0x59, 0x64, 0xff, 0x21, 0x67,
+                          0xf6, 0xec, 0xed, 0xd4, 0x19, 0xdb, 0x06, 0xc1};
+    test_assert(memcmp(result, expected, 32) == 0);
+    printf("  ✓ NIST test vector correct\n");
+  }
+
+  printf("Test 15: Context reuse after finalization\n");
+  {
+    sys_hash_t hash = sys_hash_init(sys_hash_md5);
+    test_assert(sys_hash_update(&hash, "first", 5) == true);
+    const uint8_t *result1 = sys_hash_finalize(&hash);
+    test_assert(result1 != NULL);
+
+    // Context should be unusable after finalization
+    test_assert(sys_hash_update(&hash, "second", 6) == false);
+    const uint8_t *result2 = sys_hash_finalize(&hash);
+    test_assert(result2 == NULL);
+    printf("  ✓ Context reuse prevention works\n");
+  }
+
+  printf("All hash function tests completed successfully!\n");
+  return 0;
+}


### PR DESCRIPTION
This PR adds cryptographic hash function support to the runtime system. It introduces a new sys_hash_* API supporting MD5 and SHA-256 algorithms using OpenSSL as the backend implementation.

Implements a complete hash API with initialization, updating, and finalization operations
Adds comprehensive test coverage with known test vectors and error handling scenarios
Updates build system to include OpenSSL dependencies for Linux and Darwin platforms