### PR TITLE
djt-0727-hash

### DIFF
--- a/include/runtime-sys/hash.h
+++ b/include/runtime-sys/hash.h
@@ -54,8 +54,11 @@ typedef struct {
   uint8_t hash[SYS_HASH_SIZE]; // Buffer to hold the hash value = max is SHA-256
                                // (32 bytes)
   size_t size;                 // Size of the hash in bytes
-  uint8_t ctx[SYS_HASH_CTX_SIZE]; // Context buffer large enough for any hash
-                                  // algorithm
+  union {
+    void *ptr; // Pointer to the hash context (OpenSSL EVP_MD_CTX)
+    uint8_t ctx[SYS_HASH_CTX_SIZE]; // Context buffer large enough for any hash
+                                    // algorithm
+  } ctx; // Union to hold either a pointer or a fixed-size context buffer
 } sys_hash_t;
 
 /**

--- a/include/runtime-sys/hash.h
+++ b/include/runtime-sys/hash.h
@@ -15,6 +15,24 @@ extern "C" {
 #endif
 
 /**
+ * @brief Size of the hash.
+ * @ingroup System
+ *
+ * This defines the size of the hash value produced by the hash operations.
+ * It should be large enough to hold any hash algorithm's output.
+ */
+#define SYS_HASH_SIZE 32
+
+/**
+ * @brief Size of the hash context buffer.
+ * @ingroup System
+ *
+ * This defines the size of the context buffer used for hash operations.
+ * It should be large enough to hold any hash algorithm's context.
+ */
+#define SYS_HASH_CTX_SIZE 128
+
+/**
  * @brief Hash algorithm identifiers.
  * @ingroup System
  *
@@ -33,9 +51,11 @@ typedef enum {
  */
 typedef struct {
   sys_hash_algorithm_t algorithm; // The hash algorithm used
-  uint8_t hash[32]; // Buffer to hold the hash value = max is SHA-256 (32 bytes)
-  size_t size;      // Size of the hash in bytes
-  uint8_t ctx[SYS_HASH_CTX_SIZE]; // Context buffer large enough for any hash algorithm
+  uint8_t hash[SYS_HASH_SIZE]; // Buffer to hold the hash value = max is SHA-256
+                               // (32 bytes)
+  size_t size;                 // Size of the hash in bytes
+  uint8_t ctx[SYS_HASH_CTX_SIZE]; // Context buffer large enough for any hash
+                                  // algorithm
 } sys_hash_t;
 
 /**

--- a/include/runtime-sys/hash.h
+++ b/include/runtime-sys/hash.h
@@ -35,7 +35,7 @@ typedef struct {
   sys_hash_algorithm_t algorithm; // The hash algorithm used
   uint8_t hash[32]; // Buffer to hold the hash value = max is SHA-256 (32 bytes)
   size_t size;      // Size of the hash in bytes
-  uint8_t ctx[128]; // Context buffer large enough for any hash algorithm
+  uint8_t ctx[SYS_HASH_CTX_SIZE]; // Context buffer large enough for any hash algorithm
 } sys_hash_t;
 
 /**

--- a/include/runtime-sys/hash.h
+++ b/include/runtime-sys/hash.h
@@ -16,30 +16,31 @@ extern "C" {
 
 /**
  * @brief Hash algorithm identifiers.
- * @ingroup System 
+ * @ingroup System
  *
  * Enumeration of supported cryptographic hash algorithms.
  */
 typedef enum {
-  sys_hash_md5,    // MD5 hash (128-bit)
-  sys_hash_sha256, // SHA-256 hash (256-bit)
+  sys_hash_md5 = 1, // MD5 hash (128-bit)
+  sys_hash_sha256,  // SHA-256 hash (256-bit)
 } sys_hash_algorithm_t;
 
 /**
  * @brief Hash context structure.
- * @ingroup System  
+ * @ingroup System
  *
  * Contains the state and result buffer for hash operations.
  */
 typedef struct {
+  sys_hash_algorithm_t algorithm; // The hash algorithm used
   uint8_t hash[32]; // Buffer to hold the hash value = max is SHA-256 (32 bytes)
   size_t size;      // Size of the hash in bytes
-  void *ctx;        // Any context needed for the hash operation
+  uint8_t ctx[128]; // Context buffer large enough for any hash algorithm
 } sys_hash_t;
 
 /**
  * @brief Initializes a new hash context for the specified algorithm.
- * @ingroup System  
+ * @ingroup System
  * @param algorithm The hash algorithm to use.
  * @return A new sys_hash_t instance initialized for the specified algorithm.
  *
@@ -56,7 +57,7 @@ extern sys_hash_t sys_hash_init(sys_hash_algorithm_t algorithm);
 
 /**
  * @brief Returns the size of the hash in bytes.
- * @ingroup System  
+ * @ingroup System
  * @param hash The hash context to query.
  * @return The size of the hash in bytes.
  *
@@ -68,7 +69,7 @@ extern size_t sys_hash_size(sys_hash_t *hash);
 
 /**
  * @brief Updates the hash context with new data.
- * @ingroup System  
+ * @ingroup System
  * @param hash The hash context to update.
  * @param data The data to add to the hash.
  * @param size The size of the data in bytes.
@@ -78,7 +79,7 @@ extern bool sys_hash_update(sys_hash_t *hash, const void *data, size_t size);
 
 /**
  * @brief Finalizes the hash computation and returns the hash value.
- * @ingroup System  
+ * @ingroup System
  * @param hash The hash context to finalize.
  * @return A pointer to the computed hash value, or NULL on failure.
  *

--- a/src/runtime-sys/linux/CMakeLists.txt
+++ b/src/runtime-sys/linux/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(${NAME} STATIC
     mutex.c
     sys.c
     ../openssl/hash.c
-    ../posix/malloc.c
+    ../posix/memory.c
     ../posix/puts.c
     ../posix/random.c
     ../posix/sleep.c

--- a/src/runtime-sys/openssl/hash.c
+++ b/src/runtime-sys/openssl/hash.c
@@ -9,6 +9,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 /**
  * @brief Initializes a new hash context for the specified algorithm.
@@ -16,30 +17,37 @@
 sys_hash_t sys_hash_init(sys_hash_algorithm_t algorithm) {
   sys_hash_t hash;
   hash.size = 0;
-  hash.ctx = EVP_MD_CTX_new();
+  hash.algorithm = 0; // Initialize to invalid state
 
-  if (hash.ctx == NULL) {
+  // Store a pointer to the EVP_MD_CTX in our context buffer
+  // We'll allocate it dynamically since EVP_MD_CTX is opaque in OpenSSL 3.x
+  EVP_MD_CTX **ctx_ptr = (EVP_MD_CTX **)hash.ctx;
+  *ctx_ptr = EVP_MD_CTX_new();
+
+  if (*ctx_ptr == NULL) {
     // Failed to allocate context
     return hash;
   }
 
   switch (algorithm) {
   case sys_hash_md5:
-    if (EVP_DigestInit_ex(hash.ctx, EVP_md5(), NULL)) {
+    if (EVP_DigestInit_ex(*ctx_ptr, EVP_md5(), NULL)) {
       hash.size = 16; // MD5 produces a 128-bit hash
+      hash.algorithm = algorithm;
     }
     break;
   case sys_hash_sha256:
-    if (EVP_DigestInit_ex(hash.ctx, EVP_sha256(), NULL)) {
+    if (EVP_DigestInit_ex(*ctx_ptr, EVP_sha256(), NULL)) {
       hash.size = 32; // SHA-256 produces a 256-bit hash
+      hash.algorithm = algorithm;
     }
     break;
   }
 
-  // If initialization failed, clean up and reset
+  // If initialization failed, clean up
   if (hash.size == 0) {
-    EVP_MD_CTX_free(hash.ctx);
-    hash.ctx = NULL;
+    EVP_MD_CTX_free(*ctx_ptr);
+    *ctx_ptr = NULL;
   }
 
   // Return the initialized hash context
@@ -60,25 +68,31 @@ size_t sys_hash_size(sys_hash_t *hash) {
  * @brief Updates the hash context with new data.
  */
 bool sys_hash_update(sys_hash_t *hash, const void *data, size_t size) {
-  if (data == NULL || hash == NULL || hash->ctx == NULL) {
+  if (data == NULL || hash == NULL || hash->algorithm == 0 || hash->size == 0) {
     return false;
   }
   if (size == 0) {
     return true; // No data to update, consider it a success
   }
-  return EVP_DigestUpdate(hash->ctx, data, size) ? true : false;
+  EVP_MD_CTX **ctx_ptr = (EVP_MD_CTX **)hash->ctx;
+  return EVP_DigestUpdate(*ctx_ptr, data, size) ? true : false;
 }
 
 /**
  * @brief Finalizes the hash computation and returns the hash value.
  */
 const uint8_t *sys_hash_finalize(sys_hash_t *hash) {
-  bool result = false;
-  if (hash && hash->ctx) {
-    result = EVP_DigestFinal_ex(hash->ctx, hash->hash, NULL) ? true : false;
-    EVP_MD_CTX_free(hash->ctx); // Clean up the context
-    hash->ctx = NULL;
-    // Don't reset size - leave it so caller knows the hash length
+  if (hash == NULL || hash->algorithm == 0 || hash->size == 0) {
+    return NULL; // Invalid context
   }
+
+  EVP_MD_CTX **ctx_ptr = (EVP_MD_CTX **)hash->ctx;
+  bool result = EVP_DigestFinal_ex(*ctx_ptr, hash->hash, NULL) ? true : false;
+  EVP_MD_CTX_free(*ctx_ptr); // Clean up the context
+  *ctx_ptr = NULL;
+
+  // Set algorithm to zero to indicate finalization
+  hash->algorithm = 0;
+
   return result ? hash->hash : NULL;
 }

--- a/src/runtime-sys/pico/CMakeLists.txt
+++ b/src/runtime-sys/pico/CMakeLists.txt
@@ -7,6 +7,7 @@ pico_sdk_init()
 
 add_library(${NAME} STATIC
     abort.c
+    hash.c
     memory.c
     puts.c
     random.c
@@ -21,8 +22,12 @@ target_include_directories(${NAME} PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/../../../include
     ${CMAKE_CURRENT_LIST_DIR}/../../../include/runtime-${RUNTIME}
 )
+target_include_directories(${NAME} PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}
+)
 target_link_libraries(${NAME} 
     pico_stdlib
     pico_rand
     pico_time
+    pico_mbedtls
 )

--- a/src/runtime-sys/pico/hash.c
+++ b/src/runtime-sys/pico/hash.c
@@ -1,0 +1,112 @@
+/**
+ * @file hash.c
+ * @brief Implements hash generation functionality using mbedTLS.
+ *
+ * This file implements various system methods for hash generation.
+ */
+#include <mbedtls/md5.h>
+#include <mbedtls/sha256.h>
+#include <runtime-sys/sys.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @brief Initializes a new hash context for the specified algorithm.
+ */
+sys_hash_t sys_hash_init(sys_hash_algorithm_t algorithm) {
+  sys_hash_t hash;
+  hash.size = 0;
+  hash.algorithm = 0;
+
+  switch (algorithm) {
+  case sys_hash_md5:
+    if (sizeof(mbedtls_md5_context) > sizeof(hash.ctx)) {
+      break;
+    }
+    mbedtls_md5_init((mbedtls_md5_context *)hash.ctx);
+    if (mbedtls_md5_starts_ret((mbedtls_md5_context *)hash.ctx) == 0) {
+      hash.size = 16; // MD5 produces a 128-bit hash
+      hash.algorithm = algorithm;
+    }
+    break;
+  case sys_hash_sha256:
+    if (sizeof(mbedtls_sha256_context) > sizeof(hash.ctx)) {
+      break;
+    }
+    mbedtls_sha256_init((mbedtls_sha256_context *)hash.ctx);
+    if (mbedtls_sha256_starts_ret((mbedtls_sha256_context *)hash.ctx, 0) == 0) {
+      hash.size = 32; // SHA-256 produces a 256-bit hash
+      hash.algorithm = algorithm;
+    }
+    break;
+  }
+
+  // Return the initialized hash context
+  return hash;
+}
+
+/**
+ * @brief Returns the size of the hash in bytes.
+ */
+size_t sys_hash_size(sys_hash_t *hash) {
+  if (hash) {
+    return hash->size;
+  }
+  return 0; // Handle error case
+}
+
+/**
+ * @brief Updates the hash context with new data.
+ */
+bool sys_hash_update(sys_hash_t *hash, const void *data, size_t size) {
+  if (data == NULL || hash == NULL || hash->algorithm == 0 || hash->size == 0) {
+    return false;
+  }
+  if (size == 0) {
+    return true; // No data to update, consider it a success
+  }
+  switch (hash->algorithm) {
+  case sys_hash_md5:
+    return mbedtls_md5_update_ret((mbedtls_md5_context *)hash->ctx, data,
+                                  size) == 0;
+  case sys_hash_sha256:
+    return mbedtls_sha256_update_ret((mbedtls_sha256_context *)hash->ctx, data,
+                                     size) == 0;
+  }
+  return false;
+}
+
+/**
+ * @brief Finalizes the hash computation and returns the hash value.
+ */
+const uint8_t *sys_hash_finalize(sys_hash_t *hash) {
+  if (hash == NULL || hash->algorithm == 0 || hash->size == 0) {
+    return NULL; // Invalid context
+  }
+
+  bool result = false;
+  switch (hash->algorithm) {
+  case sys_hash_md5:
+    if (mbedtls_md5_finish_ret((mbedtls_md5_context *)hash->ctx, hash->hash) ==
+        0) {
+      result = true;
+    }
+    mbedtls_md5_free((mbedtls_md5_context *)hash->ctx);
+    break;
+  case sys_hash_sha256:
+    if (mbedtls_sha256_finish_ret((mbedtls_sha256_context *)hash->ctx,
+                                  hash->hash) == 0) {
+      result = true;
+    }
+    mbedtls_sha256_free((mbedtls_sha256_context *)hash->ctx);
+    break;
+  }
+
+  // Set algorithm to zero to indicate finalization,
+  // but leave size as is
+  hash->algorithm = 0;
+
+  // Clear the context and mark as finalized
+  return result ? hash->hash : NULL;
+}

--- a/src/runtime-sys/pico/hash.c
+++ b/src/runtime-sys/pico/hash.c
@@ -21,21 +21,22 @@ sys_hash_t sys_hash_init(sys_hash_algorithm_t algorithm) {
 
   switch (algorithm) {
   case sys_hash_md5:
-    if (sizeof(mbedtls_md5_context) > sizeof(hash.ctx)) {
+    if (sizeof(mbedtls_md5_context) > sizeof(hash.ctx.ctx)) {
       break;
     }
-    mbedtls_md5_init((mbedtls_md5_context *)hash.ctx);
-    if (mbedtls_md5_starts_ret((mbedtls_md5_context *)hash.ctx) == 0) {
+    mbedtls_md5_init((mbedtls_md5_context *)hash.ctx.ctx);
+    if (mbedtls_md5_starts_ret((mbedtls_md5_context *)hash.ctx.ctx) == 0) {
       hash.size = 16; // MD5 produces a 128-bit hash
       hash.algorithm = algorithm;
     }
     break;
   case sys_hash_sha256:
-    if (sizeof(mbedtls_sha256_context) > sizeof(hash.ctx)) {
+    if (sizeof(mbedtls_sha256_context) > sizeof(hash.ctx.ctx)) {
       break;
     }
-    mbedtls_sha256_init((mbedtls_sha256_context *)hash.ctx);
-    if (mbedtls_sha256_starts_ret((mbedtls_sha256_context *)hash.ctx, 0) == 0) {
+    mbedtls_sha256_init((mbedtls_sha256_context *)hash.ctx.ctx);
+    if (mbedtls_sha256_starts_ret((mbedtls_sha256_context *)hash.ctx.ctx, 0) ==
+        0) {
       hash.size = 32; // SHA-256 produces a 256-bit hash
       hash.algorithm = algorithm;
     }
@@ -68,11 +69,11 @@ bool sys_hash_update(sys_hash_t *hash, const void *data, size_t size) {
   }
   switch (hash->algorithm) {
   case sys_hash_md5:
-    return mbedtls_md5_update_ret((mbedtls_md5_context *)hash->ctx, data,
+    return mbedtls_md5_update_ret((mbedtls_md5_context *)hash->ctx.ctx, data,
                                   size) == 0;
   case sys_hash_sha256:
-    return mbedtls_sha256_update_ret((mbedtls_sha256_context *)hash->ctx, data,
-                                     size) == 0;
+    return mbedtls_sha256_update_ret((mbedtls_sha256_context *)hash->ctx.ctx,
+                                     data, size) == 0;
   }
   return false;
 }
@@ -88,18 +89,18 @@ const uint8_t *sys_hash_finalize(sys_hash_t *hash) {
   bool result = false;
   switch (hash->algorithm) {
   case sys_hash_md5:
-    if (mbedtls_md5_finish_ret((mbedtls_md5_context *)hash->ctx, hash->hash) ==
-        0) {
+    if (mbedtls_md5_finish_ret((mbedtls_md5_context *)hash->ctx.ctx,
+                               hash->hash) == 0) {
       result = true;
     }
-    mbedtls_md5_free((mbedtls_md5_context *)hash->ctx);
+    mbedtls_md5_free((mbedtls_md5_context *)hash->ctx.ctx);
     break;
   case sys_hash_sha256:
-    if (mbedtls_sha256_finish_ret((mbedtls_sha256_context *)hash->ctx,
+    if (mbedtls_sha256_finish_ret((mbedtls_sha256_context *)hash->ctx.ctx,
                                   hash->hash) == 0) {
       result = true;
     }
-    mbedtls_sha256_free((mbedtls_sha256_context *)hash->ctx);
+    mbedtls_sha256_free((mbedtls_sha256_context *)hash->ctx.ctx);
     break;
   }
 

--- a/src/runtime-sys/pico/mbedtls_config.h
+++ b/src/runtime-sys/pico/mbedtls_config.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// Enable MD5 support
+#define MBEDTLS_MD5_C
+
+// Enable SHA-256 support, with hardware acceleration if available
+#if LIB_PICO_SHA256
+#define MBEDTLS_SHA256_ALT
+#else
+#define MBEDTLS_SHA256_C
+#endif

--- a/src/runtime-sys/pico/timeget.c
+++ b/src/runtime-sys/pico/timeget.c
@@ -25,8 +25,13 @@ bool sys_time_get_utc(sys_time_t *time) {
   return true;
 }
 
+/*
+ ** @brief Hacky implementation of gmtime because the newlib version
+ ** didn't seem to work, and I need to investigate further.
+ ** @todo Investigate why newlib's gmtime doesn't work as expected.
+ */
 struct tm *gmtime(const time_t *clock) {
-  __thread struct tm _tm;
+  struct tm _tm;
   if (clock == NULL) {
     return NULL;
   }

--- a/src/tests/sys_05/main.c
+++ b/src/tests/sys_05/main.c
@@ -1,6 +1,5 @@
 #include <runtime-sys/hash.h>
 #include <runtime-sys/sys.h>
-#include <stdio.h>
 #include <string.h>
 #include <tests/tests.h>
 
@@ -13,27 +12,27 @@ int main(void) {
 }
 
 int test_sys_05(void) {
-  printf("Test 1: Hash initialization - MD5\n");
+  sys_printf("Test 1: Hash initialization - MD5\n");
   {
     sys_hash_t hash = sys_hash_init(sys_hash_md5);
     test_assert(sys_hash_size(&hash) == 16); // MD5 is 128 bits = 16 bytes
     // Cleanup is handled by sys_hash_finalize, but we need to call it to clean
     // up
     sys_hash_finalize(&hash);
-    printf("  ✓ MD5 initialization works\n");
+    sys_printf("  ✓ MD5 initialization works\n");
   }
 
-  printf("Test 2: Hash initialization - SHA256\n");
+  sys_printf("Test 2: Hash initialization - SHA256\n");
   {
     sys_hash_t hash = sys_hash_init(sys_hash_sha256);
     test_assert(sys_hash_size(&hash) == 32); // SHA-256 is 256 bits = 32 bytes
     // Cleanup is handled by sys_hash_finalize, but we need to call it to clean
     // up
     sys_hash_finalize(&hash);
-    printf("  ✓ SHA-256 initialization works\n");
+    sys_printf("  ✓ SHA-256 initialization works\n");
   }
 
-  printf("Test 3: MD5 hash of empty string\n");
+  sys_printf("Test 3: MD5 hash of empty string\n");
   {
     sys_hash_t hash = sys_hash_init(sys_hash_md5);
     const uint8_t *result = sys_hash_finalize(&hash);
@@ -43,10 +42,10 @@ int test_sys_05(void) {
     uint8_t expected[] = {0xd4, 0x1d, 0x8c, 0xd9, 0x8f, 0x00, 0xb2, 0x04,
                           0xe9, 0x80, 0x09, 0x98, 0xec, 0xf8, 0x42, 0x7e};
     test_assert(memcmp(result, expected, 16) == 0);
-    printf("  ✓ MD5 empty string hash correct\n");
+    sys_printf("  ✓ MD5 empty string hash correct\n");
   }
 
-  printf("Test 4: SHA-256 hash of empty string\n");
+  sys_printf("Test 4: SHA-256 hash of empty string\n");
   {
     sys_hash_t hash = sys_hash_init(sys_hash_sha256);
     const uint8_t *result = sys_hash_finalize(&hash);
@@ -59,10 +58,10 @@ int test_sys_05(void) {
                           0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c,
                           0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55};
     test_assert(memcmp(result, expected, 32) == 0);
-    printf("  ✓ SHA-256 empty string hash correct\n");
+    sys_printf("  ✓ SHA-256 empty string hash correct\n");
   }
 
-  printf("Test 5: MD5 hash of 'abc'\n");
+  sys_printf("Test 5: MD5 hash of 'abc'\n");
   {
     sys_hash_t hash = sys_hash_init(sys_hash_md5);
     const char *input = "abc";
@@ -74,10 +73,10 @@ int test_sys_05(void) {
     uint8_t expected[] = {0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0,
                           0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72};
     test_assert(memcmp(result, expected, 16) == 0);
-    printf("  ✓ MD5 'abc' hash correct\n");
+    sys_printf("  ✓ MD5 'abc' hash correct\n");
   }
 
-  printf("Test 6: SHA-256 hash of 'abc'\n");
+  sys_printf("Test 6: SHA-256 hash of 'abc'\n");
   {
     sys_hash_t hash = sys_hash_init(sys_hash_sha256);
     const char *input = "abc";
@@ -92,10 +91,10 @@ int test_sys_05(void) {
                           0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
                           0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad};
     test_assert(memcmp(result, expected, 32) == 0);
-    printf("  ✓ SHA-256 'abc' hash correct\n");
+    sys_printf("  ✓ SHA-256 'abc' hash correct\n");
   }
 
-  printf("Test 7: Multiple updates - MD5\n");
+  sys_printf("Test 7: Multiple updates - MD5\n");
   {
     sys_hash_t hash = sys_hash_init(sys_hash_md5);
 
@@ -111,10 +110,10 @@ int test_sys_05(void) {
     uint8_t expected[] = {0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0,
                           0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72};
     test_assert(memcmp(result, expected, 16) == 0);
-    printf("  ✓ Multiple updates work correctly\n");
+    sys_printf("  ✓ Multiple updates work correctly\n");
   }
 
-  printf("Test 8: Large data hashing - SHA-256\n");
+  sys_printf("Test 8: Large data hashing - SHA-256\n");
   {
     sys_hash_t hash = sys_hash_init(sys_hash_sha256);
 
@@ -127,10 +126,10 @@ int test_sys_05(void) {
     const uint8_t *result = sys_hash_finalize(&hash);
     test_assert(result != NULL);
     test_assert(sys_hash_size(&hash) == 32);
-    printf("  ✓ Large data hashing works\n");
+    sys_printf("  ✓ Large data hashing works\n");
   }
 
-  printf("Test 9: Binary data hashing\n");
+  sys_printf("Test 9: Binary data hashing\n");
   {
     sys_hash_t hash = sys_hash_init(sys_hash_sha256);
 
@@ -143,10 +142,10 @@ int test_sys_05(void) {
     test_assert(sys_hash_update(&hash, binary_data, 256) == true);
     const uint8_t *result = sys_hash_finalize(&hash);
     test_assert(result != NULL);
-    printf("  ✓ Binary data hashing works\n");
+    sys_printf("  ✓ Binary data hashing works\n");
   }
 
-  printf("Test 10: Error handling - NULL data\n");
+  sys_printf("Test 10: Error handling - NULL data\n");
   {
     sys_hash_t hash = sys_hash_init(sys_hash_md5);
 
@@ -158,10 +157,10 @@ int test_sys_05(void) {
 
     // Cleanup context
     sys_hash_finalize(&hash);
-    printf("  ✓ NULL data handling works\n");
+    sys_printf("  ✓ NULL data handling works\n");
   }
 
-  printf("Test 11: Error handling - invalid context\n");
+  sys_printf("Test 11: Error handling - invalid context\n");
   {
     sys_hash_t hash = {0}; // Uninitialized hash
 
@@ -169,10 +168,10 @@ int test_sys_05(void) {
     test_assert(sys_hash_update(&hash, "test", 4) == false);
     test_assert(sys_hash_finalize(&hash) == NULL);
     test_assert(sys_hash_size(&hash) == 0);
-    printf("  ✓ Invalid context handling works\n");
+    sys_printf("  ✓ Invalid context handling works\n");
   }
 
-  printf("Test 12: Hash size after finalization\n");
+  sys_printf("Test 12: Hash size after finalization\n");
   {
     sys_hash_t hash = sys_hash_init(sys_hash_sha256);
     test_assert(sys_hash_update(&hash, "test", 4) == true);
@@ -185,10 +184,10 @@ int test_sys_05(void) {
 
     // Size should still be available after finalization
     test_assert(sys_hash_size(&hash) == 32);
-    printf("  ✓ Hash size persistence works\n");
+    sys_printf("  ✓ Hash size persistence works\n");
   }
 
-  printf("Test 13: Finalization behavior\n");
+  sys_printf("Test 13: Finalization behavior\n");
   {
     sys_hash_t hash = sys_hash_init(sys_hash_md5);
     test_assert(sys_hash_update(&hash, "partial", 7) == true);
@@ -200,10 +199,10 @@ int test_sys_05(void) {
     // Context should be unusable after finalization
     test_assert(sys_hash_update(&hash, "more", 4) == false);
     test_assert(sys_hash_finalize(&hash) == NULL);
-    printf("  ✓ Cleanup without finalization works\n");
+    sys_printf("  ✓ Cleanup without finalization works\n");
   }
 
-  printf("Test 14: Known test vectors - SHA-256\n");
+  sys_printf("Test 14: Known test vectors - SHA-256\n");
   {
     // Test with NIST test vector:
     // "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
@@ -221,10 +220,10 @@ int test_sys_05(void) {
                           0xa3, 0x3c, 0xe4, 0x59, 0x64, 0xff, 0x21, 0x67,
                           0xf6, 0xec, 0xed, 0xd4, 0x19, 0xdb, 0x06, 0xc1};
     test_assert(memcmp(result, expected, 32) == 0);
-    printf("  ✓ NIST test vector correct\n");
+    sys_printf("  ✓ NIST test vector correct\n");
   }
 
-  printf("Test 15: Context reuse after finalization\n");
+  sys_printf("Test 15: Context reuse after finalization\n");
   {
     sys_hash_t hash = sys_hash_init(sys_hash_md5);
     test_assert(sys_hash_update(&hash, "first", 5) == true);
@@ -235,9 +234,9 @@ int test_sys_05(void) {
     test_assert(sys_hash_update(&hash, "second", 6) == false);
     const uint8_t *result2 = sys_hash_finalize(&hash);
     test_assert(result2 == NULL);
-    printf("  ✓ Context reuse prevention works\n");
+    sys_printf("  ✓ Context reuse prevention works\n");
   }
 
-  printf("All hash function tests completed successfully!\n");
+  sys_printf("All hash function tests completed successfully!\n");
   return 0;
 }


### PR DESCRIPTION
This PR implements hash generation functionality across multiple platforms (Pico, OpenSSL/Linux) and adds comprehensive test coverage. The changes standardize the hash API interface and replace standard printf with sys_printf in tests.

Adds hash implementation using mbedTLS for Pico platform and updates OpenSSL implementation
Modifies hash context structure to use fixed-size buffer instead of void pointer
Updates test suite to use sys_printf instead of standard printf
