### PR TITLE
Concerted NXDate methods to use date not time

### DIFF
--- a/include/NXFoundation/NXDate.h
+++ b/include/NXFoundation/NXDate.h
@@ -21,15 +21,15 @@
  */
 @interface NXDate : NXObject <JSONProtocol> {
 @protected
-  sys_time_t _time; ///< Time representation
+  sys_date_t _date; ///< Date and time representation
 @private
-  uint16_t _year;   ///< Cached year component (1-9999)
-  uint8_t _month;   ///< Cached month component (1-12)
-  uint8_t _day;     ///< Cached day component (1-31)
-  uint8_t _weekday; ///< Cached weekday component (0-6, Sunday=0)
-  uint8_t _hours;   ///< Cached hours component (0-23)
-  uint8_t _minutes; ///< Cached minutes component (0-59)
-  uint8_t _seconds; ///< Cached seconds component (0-59)
+  uint16_t _year;   ///< Cached UTC year component (1-9999)
+  uint8_t _month;   ///< Cached UTC month component (1-12)
+  uint8_t _day;     ///< Cached UTC day component (1-31)
+  uint8_t _weekday; ///< Cached UTC weekday component (0-6, Sunday=0)
+  uint8_t _hours;   ///< Cached UTC hours component (0-23)
+  uint8_t _minutes; ///< Cached UTC minutes component (0-59)
+  uint8_t _seconds; ///< Cached UTC seconds component (0-59)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -54,7 +54,7 @@
 // PROPERTIES
 
 /**
- * @brief Retrieves the date components from this date.
+ * @brief Retrieves the date components from this date, in universal time.
  * @param year Pointer to store the year (e.g., 2025). Can be NULL if not
  * needed.
  * @param month Pointer to store the month (1-12). Can be NULL if not needed.
@@ -70,7 +70,7 @@
      weekday:(uint8_t *)weekday;
 
 /**
- * @brief Retrieves the time components from this date.
+ * @brief Retrieves the time components from this date, in universal time.
  * @param hours Pointer to store the hours (0-23). Can be NULL if not needed.
  * @param minutes Pointer to store the minutes (0-59). Can be NULL if not
  * needed.
@@ -87,18 +87,19 @@
     nanoseconds:(uint32_t *)nanoseconds;
 
 /**
- * @brief Sets the date components for this date object.
+ * @brief Sets the date components for this date object, in universal time.
  * @param year The year to set (e.g., 2025).
  * @param month The month to set (1-12).
  * @param day The day of month to set (1-31).
  * @return YES if the date was set successfully, NO if the date is invalid.
+ * @note Date is set in UTC timezone.
  * @note Invalid dates (e.g., February 30th) will cause this method to return
  * NO.
  */
 - (BOOL)setYear:(uint16_t)year month:(uint8_t)month day:(uint8_t)day;
 
 /**
- * @brief Sets the time components for this date object.
+ * @brief Sets the time components for this date object, in universal time.
  * @param hours The hours to set (0-23).
  * @param minutes The minutes to set (0-59).
  * @param seconds The seconds to set (0-59).

--- a/src/NXFoundation/NXDate.m
+++ b/src/NXFoundation/NXDate.m
@@ -274,7 +274,7 @@
 - (NXDate *)dateByAddingTimeInterval:(NXTimeInterval)interval {
   NXDate *newDate = [[NXDate alloc] init];
   if (newDate) {
-    newDate->_date = _date;             // Copy the current date
+    newDate->_date = _date;             // Copy the current date and time
     [newDate addTimeInterval:interval]; // Add the interval
   }
   return [newDate autorelease];

--- a/src/tests/NXFoundation_09/main.m
+++ b/src/tests/NXFoundation_09/main.m
@@ -11,15 +11,15 @@ int main() {
   NXZone *zone = [NXZone zoneWithSize:1024];
   NXAutoreleasePool *pool = [[NXAutoreleasePool alloc] init];
 
-  // Test the underlying sys_time_get_utc function first
-  sys_time_t test_time;
-  bool time_success = sys_time_get_utc(&test_time);
-  printf("sys_time_get_utc success: %d\n", time_success);
-  if (time_success) {
-    printf("Current time: %lld seconds, %d nanoseconds\n",
-           (long long)test_time.seconds, test_time.nanoseconds);
+  // Test the underlying sys_date_get_now function first
+  sys_date_t test_date;
+  bool date_success = sys_date_get_now(&test_date);
+  printf("sys_date_get_now success: %d\n", date_success);
+  if (date_success) {
+    printf("Current date: %lld seconds, %d nanoseconds\n",
+           (long long)test_date.seconds, test_date.nanoseconds);
   }
-  test_assert(time_success);
+  test_assert(date_success);
 
   // Test 1: Create current date
   printf("\nTest 1: Creating current date...\n");


### PR DESCRIPTION
This PR refactors the NXDate class to use a new date-based API instead of the previous time-based API. The change updates all references from sys_time_* functions and sys_time_t type to use sys_date_* functions and sys_date_t type, improving clarity and consistency in the codebase.

Key changes:

Replaced underlying time representation with date representation
Updated all system calls to use the new date-based API
Enhanced documentation to clarify UTC timezone usage