### PR TITLE
Added mono framebuffer and env

### DIFF
--- a/include/runtime-pix/types.h
+++ b/include/runtime-pix/types.h
@@ -34,9 +34,7 @@ typedef struct {
  */
 typedef enum {
   PIX_FMT_RGBA32, ///< 32-bit RGBA format with alpha channel
-  PIX_FMT_RGB332, ///< 8-bit RGB format (3-3-2 bits) without alpha
-  PIX_FMT_RGB565, ///< 16-bit RGB format (5-6-5 bits) without alpha
-  PIX_FMT_GREY1,  ///< 1-bit grayscale format (alpha mask)
+  PIX_FMT_MONO,   ///< Monochrome format (1-bit per pixel)
 } pix_format_t;
 
 /**

--- a/src/runtime-pix/CMakeLists.txt
+++ b/src/runtime-pix/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(SDL3 QUIET)
 # Base source files (always included)
 set(SOURCES
     display.c
+    mono.c
     pix.c
     rgba32.c
 )

--- a/src/runtime-pix/mono.c
+++ b/src/runtime-pix/mono.c
@@ -1,0 +1,207 @@
+#include <runtime-pix/pix.h>
+#include <runtime-sys/sys.h>
+#include <stddef.h>
+
+///////////////////////////////////////////////////////////////////////////////
+// FORWARD DECLARATIONS
+
+static void _pix_clear_rect_mono(pix_frame_t *frame, pix_color_t color,
+                                 pix_point_t origin, pix_size_t size);
+static pix_color_t _pix_get_mono(pix_frame_t *frame, pix_point_t origin);
+static void _pix_set_mono(pix_frame_t *frame, pix_color_t color,
+                          pix_point_t origin, pix_op_t op);
+static size_t _pix_get_rect_mono(pix_frame_t *frame, pix_color_t *dst,
+                                 pix_point_t origin, pix_size_t size);
+static void _pix_set_rect_mono(pix_frame_t *frame, pix_color_t *src,
+                               pix_point_t origin, pix_size_t size,
+                               pix_op_t op);
+
+///////////////////////////////////////////////////////////////////////////////
+// LIFECYCLE
+
+/**
+ * @brief Initialize a new frame with the specified format and size.
+ */
+bool _pix_frame_init_mono(pix_frame_t *frame, pix_size_t size,
+                          size_t alignment) {
+  if (frame == NULL || size.w == 0 || size.h == 0) {
+    return false; // Invalid parameters
+  }
+  if (alignment == 0) {
+    alignment = sizeof(size_t); // Default alignment
+  }
+
+  // Set up the frame structure
+  frame->format = PIX_FMT_MONO;
+  frame->offset = pix_zero_point;
+  frame->size = size;
+
+  // Calculate stride with proper alignment
+  size_t row_bytes = (size.w >> 3) * sizeof(uint8_t);
+  frame->stride =
+      (row_bytes + alignment - 1) & ~(alignment - 1); // Align stride
+
+  // Size of the buffer in bytes
+  size_t buf_size = frame->stride * size.h;
+  frame->buf = sys_malloc(buf_size);
+  if (frame->buf == NULL) {
+    return false; // Memory allocation failed
+  } else {
+    sys_memset(frame->buf, 0, buf_size); // Initialize buffer to zero
+  }
+
+  // set the function pointers
+  frame->drawable = NULL;
+  frame->clear_rect = _pix_clear_rect_mono;
+  frame->get = _pix_get_mono;
+  frame->set = _pix_set_mono;
+  frame->get_rect = _pix_get_rect_mono;
+  frame->set_rect = _pix_set_rect_mono;
+
+  // Return success
+  return true;
+}
+
+/**
+ * @brief Finalize and free resources associated with a frame.
+ */
+bool _pix_frame_finalize_mono(pix_frame_t *frame) {
+  if (frame == NULL || frame->buf == NULL) {
+    return false; // Nothing to finalize
+  }
+
+  // Release the buffer memory
+  sys_free(frame->buf);
+  frame->buf = NULL;
+  frame->size = pix_zero_size;
+  frame->offset = pix_zero_point;
+
+  // NULLify the function pointers
+  frame->drawable = NULL;
+  frame->clear_rect = NULL;
+  frame->get = NULL;
+  frame->set = NULL;
+  frame->get_rect = NULL;
+  frame->set_rect = NULL;
+
+  // Return success
+  return true;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// PRIVATE FUNCTIONS
+
+static void _pix_clear_rect_mono(pix_frame_t *frame, pix_color_t color,
+                                 pix_point_t origin, pix_size_t size) {
+  // Check drawable state
+  if (frame == NULL || frame->buf == NULL) {
+    return;
+  }
+
+  // Handle zero size (clear entire frame)
+  if (size.w == 0) {
+    size.w = frame->size.w;
+    origin.x = 0;
+  }
+  if (size.h == 0) {
+    size.h = frame->size.h;
+    origin.y = 0;
+  }
+
+  // Bounds clipping
+  if (origin.x < 0) {
+    size.w += origin.x;
+    origin.x = 0;
+  }
+  if (origin.y < 0) {
+    size.h += origin.y;
+    origin.y = 0;
+  }
+  if (origin.x + size.w > frame->size.w) {
+    size.w = frame->size.w - origin.x;
+  }
+  if (origin.y + size.h > frame->size.h) {
+    size.h = frame->size.h - origin.y;
+  }
+
+  // Early exit
+  if (size.w <= 0 || size.h <= 0) {
+    return;
+  }
+
+  // TODO: Perform drawing operation
+}
+
+static pix_color_t _pix_get_mono(pix_frame_t *frame, pix_point_t origin) {
+  // Check drawable state
+  if (frame == NULL || frame->buf == NULL) {
+    return 0; // Return transparent color if not drawable
+  } else if (frame->drawable && frame->drawable() == false) {
+    return 0; // Return transparent color if not drawable
+  }
+
+  // Suppress unused parameter warnings
+  (void)origin;
+
+  // TODO
+  return 0;
+}
+
+static void _pix_set_mono(pix_frame_t *frame, pix_color_t color,
+                          pix_point_t origin, pix_op_t op) {
+  // Check drawable state
+  if (frame == NULL || frame->buf == NULL) {
+    return;
+  } else if (frame->drawable && frame->drawable() == false) {
+    return;
+  }
+
+  // Bounds checking
+  if (origin.x < 0 || origin.y < 0 || origin.x >= frame->size.w ||
+      origin.y >= frame->size.h) {
+    return; // Out of bounds
+  }
+
+  // Suppress unused parameter warnings
+  (void)color;
+  (void)op;
+
+  // TODO
+}
+
+static size_t _pix_get_rect_mono(pix_frame_t *frame, pix_color_t *dst,
+                                 pix_point_t origin, pix_size_t size) {
+  // Check drawable state
+  if (frame == NULL || frame->buf == NULL) {
+    return 0;
+  } else if (frame->drawable && frame->drawable() == false) {
+    return 0;
+  }
+
+  // Suppress unused parameter warnings
+  (void)dst;
+  (void)origin;
+  (void)size;
+
+  // TODO
+  return 0;
+}
+
+static void _pix_set_rect_mono(pix_frame_t *frame, pix_color_t *src,
+                               pix_point_t origin, pix_size_t size,
+                               pix_op_t op) {
+  // Check drawable state
+  if (frame == NULL || frame->buf == NULL) {
+    return;
+  } else if (frame->drawable && frame->drawable() == false) {
+    return;
+  }
+
+  // Suppress unused parameter warnings
+  (void)src;
+  (void)origin;
+  (void)size;
+  (void)op;
+
+  // TODO
+}

--- a/src/runtime-pix/mono.c
+++ b/src/runtime-pix/mono.c
@@ -1,6 +1,7 @@
 #include <runtime-pix/pix.h>
 #include <runtime-sys/sys.h>
 #include <stddef.h>
+#include <runtime-pix/mono.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 // FORWARD DECLARATIONS

--- a/src/runtime-pix/mono.h
+++ b/src/runtime-pix/mono.h
@@ -1,0 +1,6 @@
+#include <runtime-pix/pix.h>
+
+bool _pix_frame_init_mono(pix_frame_t *frame, pix_size_t size,
+                          size_t alignment);
+
+bool _pix_frame_finalize_mono(pix_frame_t *frame);

--- a/src/runtime-pix/pix.c
+++ b/src/runtime-pix/pix.c
@@ -68,6 +68,11 @@ pix_frame_t pix_frame_init(pix_format_t format, pix_size_t size,
       return (pix_frame_t){0}; // Initialization failed, return empty frame
     }
     break;
+  case PIX_FMT_MONO:
+    if (_pix_frame_init_mono(&frame, size, alignment) == false) {
+      return (pix_frame_t){0}; // Initialization failed, return empty frame
+    }
+    break;
   default:
     // Unsupported format, return zero-sized frame
   }
@@ -86,6 +91,8 @@ bool pix_frame_finalize(pix_frame_t *frame) {
   switch (frame->format) {
   case PIX_FMT_RGBA32:
     return _pix_frame_finalize_rgba32(frame);
+  case PIX_FMT_MONO:
+    return _pix_frame_finalize_mono(frame);
   default:
     // Unsupported format
     return false;

--- a/src/runtime-sys/pico/CMakeLists.txt
+++ b/src/runtime-sys/pico/CMakeLists.txt
@@ -41,5 +41,4 @@ target_link_libraries(${NAME}
     pico_mbedtls
     pico_multicore
     pico_standard_binary_info
-    pico_stdio
 )

--- a/src/runtime-sys/pico/env.c
+++ b/src/runtime-sys/pico/env.c
@@ -9,15 +9,24 @@ extern binary_info_t *__binary_info_end;
 // PRIVATE FUNCTIONS
 
 const char *get_binary_info_string(uint32_t id) {
-  if (__binary_info_start == NULL || __binary_info_end == NULL) {
-    return NULL; // No binary info available
+  // The symbols are addresses, not pointers that can be NULL
+  // Cast them properly to get the array bounds
+  binary_info_t **start = (binary_info_t **)&__binary_info_start;
+  binary_info_t **end = (binary_info_t **)&__binary_info_end;
+
+  // Safety check for valid range
+  if (start >= end) {
+    return NULL;
   }
 
   // Iterate through binary info entries
-  for (binary_info_t *info = __binary_info_start; info < __binary_info_end; info++) {
+  for (binary_info_t **info_ptr = start; info_ptr < end; info_ptr++) {
+    binary_info_t *info = *info_ptr;
     if (!info) {
       continue;
     }
+
+    // Check if this is a string type with the requested ID
     if (info->type == BINARY_INFO_TYPE_ID_AND_STRING) {
       binary_info_id_and_string_t *string_info =
           (binary_info_id_and_string_t *)info;
@@ -32,13 +41,33 @@ const char *get_binary_info_string(uint32_t id) {
 
 const char *get_program_name(void) {
   const char *name = get_binary_info_string(BINARY_INFO_ID_RP_PROGRAM_NAME);
-  return name ? name : "unknown";
+  if (name) {
+    return name;
+  }
+
+  // Fallback to compile-time macro if binary info fails
+#ifdef PICO_PROGRAM_NAME
+  return PICO_PROGRAM_NAME;
+#elif defined(PICO_TARGET_NAME)
+  return PICO_TARGET_NAME;
+#else
+  return "unknown";
+#endif
 }
 
 const char *get_program_version(void) {
   const char *version =
       get_binary_info_string(BINARY_INFO_ID_RP_PROGRAM_VERSION_STRING);
-  return version ? version : "unknown";
+  if (version) {
+    return version;
+  }
+
+  // Fallback to compile-time macro if binary info fails
+#ifdef PICO_PROGRAM_VERSION_STRING
+  return PICO_PROGRAM_VERSION_STRING;
+#else
+  return "unknown";
+#endif
 }
 
 const char *get_program_description(void) {

--- a/src/runtime-sys/pico/env.c
+++ b/src/runtime-sys/pico/env.c
@@ -1,6 +1,75 @@
 #include <pico/binary_info.h>
 #include <pico/unique_id.h>
 
+// External symbols provided by the linker
+extern binary_info_t *__binary_info_start;
+extern binary_info_t *__binary_info_end;
+
+///////////////////////////////////////////////////////////////////////////////
+// PRIVATE FUNCTIONS
+
+const char *get_binary_info_string(uint32_t id) {
+  if (__binary_info_start == NULL || __binary_info_end == NULL) {
+    return NULL; // No binary info available
+  }
+
+  // Iterate through binary info entries
+  for (binary_info_t **info_ptr = (binary_info_t **)&__binary_info_start;
+       info_ptr < (binary_info_t **)&__binary_info_end; info_ptr++) {
+    binary_info_t *info = *info_ptr;
+    if (!info) {
+      continue;
+    }
+    if (info->type == BINARY_INFO_TYPE_ID_AND_STRING) {
+      binary_info_id_and_string_t *string_info =
+          (binary_info_id_and_string_t *)info;
+      if (string_info->core.tag == BINARY_INFO_TAG_RASPBERRY_PI &&
+          string_info->id == id) {
+        return (const char *)string_info->value;
+      }
+    }
+  }
+  return NULL;
+}
+
+const char *get_program_name(void) {
+  const char *name = get_binary_info_string(BINARY_INFO_ID_RP_PROGRAM_NAME);
+  return name ? name : "unknown";
+}
+
+const char *get_program_version(void) {
+  const char *version =
+      get_binary_info_string(BINARY_INFO_ID_RP_PROGRAM_VERSION_STRING);
+  return version ? version : "unknown";
+}
+
+const char *get_program_description(void) {
+  const char *desc =
+      get_binary_info_string(BINARY_INFO_ID_RP_PROGRAM_DESCRIPTION);
+  return desc ? desc : "unknown";
+}
+
+const char *get_program_url(void) {
+  const char *url = get_binary_info_string(BINARY_INFO_ID_RP_PROGRAM_URL);
+  return url ? url : "unknown";
+}
+
+const char *get_build_date(void) {
+  const char *date =
+      get_binary_info_string(BINARY_INFO_ID_RP_PROGRAM_BUILD_DATE_STRING);
+  return date ? date : "unknown";
+}
+
+const char *get_sdk_version(void) {
+  const char *sdk = get_binary_info_string(BINARY_INFO_ID_RP_SDK_VERSION);
+  return sdk ? sdk : "unknown";
+}
+
+const char *get_board_name(void) {
+  const char *board = get_binary_info_string(BINARY_INFO_ID_RP_PICO_BOARD);
+  return board ? board : "unknown";
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // PUBLIC FUNCTIONS
 
@@ -16,23 +85,9 @@ const char *sys_env_serial(void) {
 /**
  * @brief Returns the name of the current environment.
  */
-const char *sys_env_name(void) {
-#ifdef PICO_PROGRAM_NAME
-  return PICO_PROGRAM_NAME;
-#elif defined(PICO_TARGET_NAME)
-  return PICO_TARGET_NAME;
-#else
-  return "pico";
-#endif
-}
+const char *sys_env_name(void) { return get_program_name(); }
 
 /**
  * @brief Returns the version of the current environment.
  */
-const char *sys_env_version(void) {
-#ifdef PICO_PROGRAM_VERSION_STRING
-  return PICO_PROGRAM_VERSION_STRING;
-#else
-  return "unknown";
-#endif
-}
+const char *sys_env_version(void) { return get_program_version(); }

--- a/src/runtime-sys/pico/env.c
+++ b/src/runtime-sys/pico/env.c
@@ -14,9 +14,7 @@ const char *get_binary_info_string(uint32_t id) {
   }
 
   // Iterate through binary info entries
-  for (binary_info_t **info_ptr = (binary_info_t **)&__binary_info_start;
-       info_ptr < (binary_info_t **)&__binary_info_end; info_ptr++) {
-    binary_info_t *info = *info_ptr;
+  for (binary_info_t *info = __binary_info_start; info < __binary_info_end; info++) {
     if (!info) {
       continue;
     }

--- a/src/tests/sys_16/CMakeLists.txt
+++ b/src/tests/sys_16/CMakeLists.txt
@@ -9,6 +9,12 @@ add_test(NAME ${NAME} COMMAND ${NAME})
 
 # additional configurations for the Pico SDK
 if(CMAKE_SYSTEM_NAME STREQUAL "Pico")
+# Set binary info for the program
+set(PICO_PROGRAM_NAME "sys_16_test")
+set(PICO_PROGRAM_VERSION_STRING "1.0.0")
+set(PICO_PROGRAM_DESCRIPTION "System Environment Test")
+set(PICO_PROGRAM_URL "https://github.com/djthorpe/objc")
+
 pico_add_extra_outputs(${NAME})
 pico_enable_stdio_usb(${NAME} 1)
 pico_enable_stdio_uart(${NAME} 0)


### PR DESCRIPTION
This PR adds support for monochrome framebuffer functionality and enhances environment information retrieval for the Pico platform. The changes implement a new PIX_FMT_MONO pixel format and improve the system environment API to dynamically extract program metadata from binary info.

Implements monochrome pixel format support with initialization, finalization, and drawing operations
Replaces static preprocessor-based environment info with dynamic binary info extraction
Adds binary info configuration for the sys_16 test program