### PR TITLE
Updated examples

### DIFF
--- a/include/NXApplication/Application.h
+++ b/include/NXApplication/Application.h
@@ -16,6 +16,9 @@
  * in NXApplication. It follows the singleton pattern, providing a shared
  * instance that manages the application lifecycle, coordinates event
  * processing, and maintains the main run loop.
+ *
+ * @example examples/NXApplication/helloworld/main.m
+ * @example examples/NXApplication/gpio/main.m
  */
 @interface Application : NXObject {
 @private

--- a/include/runtime-pix/pix.h
+++ b/include/runtime-pix/pix.h
@@ -1,7 +1,7 @@
 /**
  * @file pix.h
  * @brief Pixel display and frame management functions.
- * @defgroup Pixel
+ * @defgroup Pixel Pixels
  * @ingroup System
  *
  * Managing pixel data, framebuffers, and drawing operations.

--- a/src/NXApplication/Application.m
+++ b/src/NXApplication/Application.m
@@ -130,7 +130,6 @@ static id sharedApplication = nil;
 
 - (int)run {
   if (_run) {
-    NXLog(@"Application is already running.");
     return 0; // Already running
   }
 
@@ -165,7 +164,6 @@ static id sharedApplication = nil;
 }
 
 - (void)stop {
-  NXLog(@"NXApplication is stopping...");
   sys_event_queue_shutdown(&_queue); // Shutdown the event queue
 }
 

--- a/src/NXApplication/ApplicationMain.m
+++ b/src/NXApplication/ApplicationMain.m
@@ -57,7 +57,12 @@ int NXApplicationMain(int argc, char *argv[], Class delegate) {
     }
   }
 
-#ifndef SYSTEM_NAME_PICO
+#ifdef SYSTEM_NAME_PICO
+  // For Pico, we set the program name as the first argument
+  NXString *programName = [NXString stringWithCString:sys_env_name()];
+  [app setArgs:[NXArray arrayWithObjects:programName, nil]];
+#else
+  // For other systems, we create an array of arguments from argc and argv
   NXArray *args = [NXArray arrayWithCapacity:argc];
   objc_assert(args);
   int i = 0;

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -5,7 +5,7 @@ include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/../../include/runtime-${RUNTIME}
 )
 
-add_subdirectory(app)
+# Unorganized examples - to be organized later!
 add_subdirectory(clock)
 add_subdirectory(bme280)
 add_subdirectory(uc8151)
@@ -16,4 +16,6 @@ add_subdirectory(pico/runloop)
 add_subdirectory(pico/gpio_runloop)
 add_subdirectory(pico/pwm_blink)
 
-
+# NXApplication examples
+add_subdirectory(NXApplication/helloworld)
+add_subdirectory(NXApplication/gpio)

--- a/src/examples/NXApplication/gpio/CMakeLists.txt
+++ b/src/examples/NXApplication/gpio/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(NAME "nxapplication_gpio")
+add_executable(${NAME}
+    main.m
+)
+target_link_libraries(${NAME} PRIVATE
+    runtime-sys
+    runtime-hw
+    NXFoundation
+    NXApplication
+)
+
+# additional configurations for the Pico SDK
+if(CMAKE_SYSTEM_NAME STREQUAL "Pico")
+pico_add_extra_outputs(${NAME})
+pico_enable_stdio_usb(${NAME} 1)
+pico_enable_stdio_uart(${NAME} 0)
+endif()

--- a/src/examples/NXApplication/gpio/main.m
+++ b/src/examples/NXApplication/gpio/main.m
@@ -1,12 +1,10 @@
 /**
- * @file main.m
- * @brief Example showing how to create a simple application that stops after
- * launching.
+ * @file  examples/NXApplication/gpio/main.m
+ * @brief Example showing how to respond to GPIO events in an NXApplication
+ * application.
  *
- * This example demonstrates how to read the system date and time,
- * format it, and print it to the console. It uses the sys_date_t structure
- * to represent the current date and time, and sys_date_get_now() to retrieve
- * the current date and time.
+ * This example demonstrates how to read the state of GPIO pins and respond to
+ * button presses.
  */
 #include <NXApplication/NXApplication.h>
 
@@ -25,8 +23,12 @@
 @implementation MyAppDelegate
 
 - (void)applicationDidFinishLaunching:(id)application {
-  (void)application; // Cast to void to avoid unused parameter warning
-  NXLog(@"Application did finish launching");
+  // If GPIO is not supported, log a warning and stop the application
+  if ([GPIO count] == 0) {
+    NXLog(@"GPIO is not supported on this platform");
+    [application stop];
+    return;
+  }
 
   // Initialize a GPIO pin for input
   [GPIO pullupWithPin:GPIO_A];

--- a/src/examples/NXApplication/helloworld/CMakeLists.txt
+++ b/src/examples/NXApplication/helloworld/CMakeLists.txt
@@ -1,11 +1,8 @@
-set(NAME "app")
+set(NAME "nxapplication_helloworld")
 add_executable(${NAME}
     main.m
 )
 target_link_libraries(${NAME} PRIVATE
-    runtime-sys
-    runtime-hw
-    NXFoundation
     NXApplication
 )
 

--- a/src/examples/NXApplication/helloworld/main.m
+++ b/src/examples/NXApplication/helloworld/main.m
@@ -1,0 +1,39 @@
+/**
+ * @file examples/NXApplication/helloworld/main.m
+ * @brief Example showing how to create a simple application that stops after
+ * launching.
+ *
+ * This example demonstrates how to start an NXApplication application
+ * with a custom delegate.
+ */
+#include <NXApplication/NXApplication.h>
+
+//////////////////////////////////////////////////////////////////////////
+
+@interface MyAppDelegate : NXObject <ApplicationDelegate>
+@end
+
+//////////////////////////////////////////////////////////////////////////
+
+@implementation MyAppDelegate
+
+- (void)applicationDidFinishLaunching:(id)application {
+  // Print out the arguments passed to the application
+  NXLog(@"Application did finish launching with arguments: %@",
+        [application args]);
+
+  // Stop the application immediately after launching
+  [application stop];
+}
+
+@end
+
+//////////////////////////////////////////////////////////////////////////
+
+int main(int argc, char *argv[]) {
+  // Initialize the NXApplication framework
+  return NXApplicationMain(argc, argv, [MyAppDelegate class]);
+}
+
+void *stdout = NULL; // Placeholder for standard output
+void *stderr = NULL; // Placeholder for standard error

--- a/src/runtime-hw/darwin/CMakeLists.txt
+++ b/src/runtime-hw/darwin/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(${NAME} STATIC
     ../stub/gpio.c
     ../stub/hw.c
     ../stub/i2c.c
+    ../stub/pwm.c
     ../stub/spi.c
 )
 target_include_directories(${NAME} PRIVATE

--- a/src/runtime-hw/linux/CMakeLists.txt
+++ b/src/runtime-hw/linux/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(${NAME} STATIC
     ../stub/gpio.c
     ../stub/hw.c
     ../stub/i2c.c
+    ../stub/pwm.c
     ../stub/spi.c
 )
 target_include_directories(${NAME} PRIVATE

--- a/src/runtime-hw/stub/i2c.c
+++ b/src/runtime-hw/stub/i2c.c
@@ -74,3 +74,33 @@ size_t hw_i2c_xfr(hw_i2c_t *i2c, uint8_t addr, void *data, size_t tx, size_t rx,
   (void)timeout_ms; // Suppress unused parameter warning
   return 0;         // Always return 0 since transfer is not implemented
 }
+
+/**
+ * @brief Read data from a specific register of an I2C device.
+ */
+size_t hw_i2c_read(hw_i2c_t *i2c, uint8_t addr, uint8_t reg, void *data,
+                   size_t len, uint32_t timeout_ms) {
+  sys_assert(i2c);
+  // I2C not implemented in stub
+  (void)addr;       // Suppress unused parameter warning
+  (void)reg;        // Suppress unused parameter warning
+  (void)data;       // Suppress unused parameter warning
+  (void)len;        // Suppress unused parameter warning
+  (void)timeout_ms; // Suppress unused parameter warning
+  return 0;         // Always return 0 since read is not implemented
+}
+
+/**
+ * @brief Write data to a specific register of an I2C device.
+ */
+size_t hw_i2c_write(hw_i2c_t *i2c, uint8_t addr, uint8_t reg, const void *data,
+                    size_t len, uint32_t timeout_ms) {
+  sys_assert(i2c);
+  // I2C not implemented in stub
+  (void)addr;       // Suppress unused parameter warning
+  (void)reg;        // Suppress unused parameter warning
+  (void)data;       // Suppress unused parameter warning
+  (void)len;        // Suppress unused parameter warning
+  (void)timeout_ms; // Suppress unused parameter warning
+  return 0;         // Always return 0 since write is not implemented
+}

--- a/src/runtime-hw/stub/pwm.c
+++ b/src/runtime-hw/stub/pwm.c
@@ -7,29 +7,14 @@
 // LIFECYCLE
 
 /**
- * @brief Get the total number of available PWM slices.
+ * @brief Initialize a PWM slice from GPIO pins.
  */
-uint8_t hw_pwm_count(void) {
-  return 0; // No PWM support in stub implementation
-}
-
-/**
- * @brief Initialize a PWM slice from a GPIO pin.
- */
-hw_pwm_t hw_pwm_init(uint8_t gpio_pin) {
-  (void)gpio_pin; // Suppress unused parameter warning
+hw_pwm_t hw_pwm_init(uint8_t gpio_x, uint8_t gpio_y, hw_pwm_config_t *config) {
+  (void)gpio_x; // Suppress unused parameter warning
+  (void)gpio_y; // Suppress unused parameter warning
+  (void)config; // Suppress unused parameter warning
   hw_pwm_t pwm = {
-      .slice = 0xFF, .gpio_a = 0xFF, .gpio_b = 0xFF, .enabled = false};
-  return pwm;
-}
-
-/**
- * @brief Initialize a specific PWM slice.
- */
-hw_pwm_t hw_pwm_init_slice(uint8_t slice) {
-  (void)slice; // Suppress unused parameter warning
-  hw_pwm_t pwm = {
-      .slice = 0xFF, .gpio_a = 0xFF, .gpio_b = 0xFF, .enabled = false};
+      .slice = 0xFF, .gpio_a = {0}, .gpio_b = {0}, .wrap = 0, .enabled = false};
   return pwm;
 }
 
@@ -45,81 +30,23 @@ void hw_pwm_finalize(hw_pwm_t *pwm) {
 // CONFIGURATION
 
 /**
- * @brief Get default PWM configuration.
+ * @brief Get PWM configuration for a frequency.
  */
-hw_pwm_config_t hw_pwm_get_default_config(void) {
-  hw_pwm_config_t config = {.wrap = 0xFFFF,
-                            .clkdiv = 1.0f,
-                            .clkdiv_mode = HW_PWM_CLKDIV_FREE_RUNNING,
-                            .phase_correct = false,
-                            .invert_a = false,
-                            .invert_b = false};
+hw_pwm_config_t hw_pwm_get_config(float freq) {
+  (void)freq; // Suppress unused parameter warning
+  hw_pwm_config_t config = {.wrap = 0xFFFF, .divider = 1.0f};
   return config;
 }
 
 /**
  * @brief Apply configuration to a PWM slice.
  */
-void hw_pwm_configure(hw_pwm_t *pwm, const hw_pwm_config_t *config,
-                      bool start) {
+void hw_pwm_set_config(hw_pwm_t *pwm, const hw_pwm_config_t *config,
+                       bool start) {
   (void)pwm;    // Suppress unused parameter warning
   (void)config; // Suppress unused parameter warning
   (void)start;  // Suppress unused parameter warning
   // No operation in stub implementation
-}
-
-/**
- * @brief Set PWM frequency and duty cycle for a simple PWM setup.
- */
-bool hw_pwm_set_frequency_duty(hw_pwm_t *pwm, float frequency_hz,
-                               float duty_percent, hw_pwm_channel_t channel) {
-  (void)pwm;          // Suppress unused parameter warning
-  (void)frequency_hz; // Suppress unused parameter warning
-  (void)duty_percent; // Suppress unused parameter warning
-  (void)channel;      // Suppress unused parameter warning
-  return false;       // Always fail in stub implementation
-}
-
-/**
- * @brief Get the actual PWM frequency being generated.
- */
-float hw_pwm_get_actual_frequency(hw_pwm_t *pwm) {
-  (void)pwm;   // Suppress unused parameter warning
-  return 0.0f; // No frequency in stub implementation
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// GPIO MANAGEMENT
-
-/**
- * @brief Assign a GPIO pin to a PWM channel.
- */
-bool hw_pwm_set_gpio(hw_pwm_t *pwm, uint8_t gpio_pin,
-                     hw_pwm_channel_t channel) {
-  (void)pwm;      // Suppress unused parameter warning
-  (void)gpio_pin; // Suppress unused parameter warning
-  (void)channel;  // Suppress unused parameter warning
-  return false;   // Always fail in stub implementation
-}
-
-/**
- * @brief Get the GPIO pin assigned to a PWM channel.
- */
-uint8_t hw_pwm_get_gpio(hw_pwm_t *pwm, hw_pwm_channel_t channel) {
-  (void)pwm;     // Suppress unused parameter warning
-  (void)channel; // Suppress unused parameter warning
-  return 0xFF;   // No GPIO assigned in stub implementation
-}
-
-/**
- * @brief Determine which PWM slice and channel a GPIO pin belongs to.
- */
-bool hw_pwm_gpio_to_slice_channel(uint8_t gpio_pin, uint8_t *slice,
-                                  hw_pwm_channel_t *channel) {
-  (void)gpio_pin; // Suppress unused parameter warning
-  (void)slice;    // Suppress unused parameter warning
-  (void)channel;  // Suppress unused parameter warning
-  return false;   // Always fail in stub implementation
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -142,129 +69,12 @@ void hw_pwm_stop(hw_pwm_t *pwm) {
 }
 
 /**
- * @brief Check if PWM is currently running.
+ * @brief Set PWM duty cycle.
  */
-bool hw_pwm_is_running(hw_pwm_t *pwm) {
-  (void)pwm;    // Suppress unused parameter warning
-  return false; // Always stopped in stub implementation
-}
-
-/**
- * @brief Set the duty cycle level for a PWM channel.
- */
-void hw_pwm_set_level(hw_pwm_t *pwm, hw_pwm_channel_t channel, uint16_t level) {
-  (void)pwm;     // Suppress unused parameter warning
-  (void)channel; // Suppress unused parameter warning
-  (void)level;   // Suppress unused parameter warning
-  // No operation in stub implementation
-}
-
-/**
- * @brief Get the current duty cycle level for a PWM channel.
- */
-uint16_t hw_pwm_get_level(hw_pwm_t *pwm, hw_pwm_channel_t channel) {
-  (void)pwm;     // Suppress unused parameter warning
-  (void)channel; // Suppress unused parameter warning
-  return 0;      // Always zero in stub implementation
-}
-
-/**
- * @brief Set the duty cycle levels for both channels simultaneously.
- */
-void hw_pwm_set_both_levels(hw_pwm_t *pwm, uint16_t level_a, uint16_t level_b) {
-  (void)pwm;     // Suppress unused parameter warning
-  (void)level_a; // Suppress unused parameter warning
-  (void)level_b; // Suppress unused parameter warning
-  // No operation in stub implementation
-}
-
-/**
- * @brief Set the wrap value (PWM period).
- */
-void hw_pwm_set_wrap(hw_pwm_t *pwm, uint16_t wrap) {
-  (void)pwm;  // Suppress unused parameter warning
-  (void)wrap; // Suppress unused parameter warning
-  // No operation in stub implementation
-}
-
-/**
- * @brief Get the current wrap value.
- */
-uint16_t hw_pwm_get_wrap(hw_pwm_t *pwm) {
-  (void)pwm;     // Suppress unused parameter warning
-  return 0xFFFF; // Default wrap value
-}
-
-/**
- * @brief Get the current PWM counter value.
- */
-uint16_t hw_pwm_get_counter(hw_pwm_t *pwm) {
-  (void)pwm; // Suppress unused parameter warning
-  return 0;  // Always zero in stub implementation
-}
-
-/**
- * @brief Set the PWM counter value.
- */
-void hw_pwm_set_counter(hw_pwm_t *pwm, uint16_t counter) {
-  (void)pwm;     // Suppress unused parameter warning
-  (void)counter; // Suppress unused parameter warning
-  // No operation in stub implementation
-}
-
-///////////////////////////////////////////////////////////////////////////////
-// ADVANCED FEATURES
-
-/**
- * @brief Set the clock divider for the PWM slice.
- */
-void hw_pwm_set_clkdiv(hw_pwm_t *pwm, float divider) {
-  (void)pwm;     // Suppress unused parameter warning
-  (void)divider; // Suppress unused parameter warning
-  // No operation in stub implementation
-}
-
-/**
- * @brief Set the clock divider mode.
- */
-void hw_pwm_set_clkdiv_mode(hw_pwm_t *pwm, hw_pwm_clkdiv_mode_t mode) {
-  (void)pwm;  // Suppress unused parameter warning
-  (void)mode; // Suppress unused parameter warning
-  // No operation in stub implementation
-}
-
-/**
- * @brief Enable or disable phase-correct mode.
- */
-void hw_pwm_set_phase_correct(hw_pwm_t *pwm, bool phase_correct) {
-  (void)pwm;           // Suppress unused parameter warning
-  (void)phase_correct; // Suppress unused parameter warning
-  // No operation in stub implementation
-}
-
-/**
- * @brief Set output polarity for PWM channels.
- */
-void hw_pwm_set_output_polarity(hw_pwm_t *pwm, bool invert_a, bool invert_b) {
-  (void)pwm;      // Suppress unused parameter warning
-  (void)invert_a; // Suppress unused parameter warning
-  (void)invert_b; // Suppress unused parameter warning
-  // No operation in stub implementation
-}
-
-/**
- * @brief Advance the PWM counter by one count.
- */
-void hw_pwm_advance_count(hw_pwm_t *pwm) {
-  (void)pwm; // Suppress unused parameter warning
-  // No operation in stub implementation
-}
-
-/**
- * @brief Retard the PWM counter by one count.
- */
-void hw_pwm_retard_count(hw_pwm_t *pwm) {
-  (void)pwm; // Suppress unused parameter warning
+void hw_pwm_set_duty(hw_pwm_t *pwm, uint8_t ch, uint8_t duty_percent) {
+  (void)pwm;          // Suppress unused parameter warning
+  (void)ch;           // Suppress unused parameter warning
+  (void)duty_percent; // Suppress unused parameter warning
   // No operation in stub implementation
 }
 
@@ -286,45 +96,5 @@ void hw_pwm_set_callback(hw_pwm_callback_t callback, void *userdata) {
 void hw_pwm_set_irq_enabled(hw_pwm_t *pwm, bool enabled) {
   (void)pwm;     // Suppress unused parameter warning
   (void)enabled; // Suppress unused parameter warning
-  // No operation in stub implementation
-}
-
-/**
- * @brief Enable or disable PWM wrap interrupts for multiple slices.
- */
-void hw_pwm_set_irq_mask_enabled(uint32_t slice_mask, bool enabled) {
-  (void)slice_mask; // Suppress unused parameter warning
-  (void)enabled;    // Suppress unused parameter warning
-  // No operation in stub implementation
-}
-
-/**
- * @brief Check if a PWM slice has a pending interrupt.
- */
-bool hw_pwm_get_irq_status(hw_pwm_t *pwm) {
-  (void)pwm;    // Suppress unused parameter warning
-  return false; // No interrupts in stub implementation
-}
-
-/**
- * @brief Clear the interrupt flag for a PWM slice.
- */
-void hw_pwm_clear_irq(hw_pwm_t *pwm) {
-  (void)pwm; // Suppress unused parameter warning
-  // No operation in stub implementation
-}
-
-/**
- * @brief Get the interrupt status mask for all PWM slices.
- */
-uint32_t hw_pwm_get_irq_status_mask(void) {
-  return 0; // No interrupts in stub implementation
-}
-
-/**
- * @brief Clear interrupt flags for multiple PWM slices.
- */
-void hw_pwm_clear_irq_mask(uint32_t slice_mask) {
-  (void)slice_mask; // Suppress unused parameter warning
   // No operation in stub implementation
 }


### PR DESCRIPTION
This PR updates and streamlines hardware abstraction layer examples by simplifying PWM and I2C stub implementations and reorganizing NXApplication examples. The changes remove redundant APIs while adding new convenience functions and improving example organization.

- Simplified PWM stub implementation by removing many unused functions and updating API signatures
- Added convenience I2C read/write functions to complement existing transfer function
- Reorganized and updated NXApplication examples with better structure and documentation
