### PR TITLE
Added signalling for applications

### DIFF
--- a/include/NXApplication/Application.h
+++ b/include/NXApplication/Application.h
@@ -29,8 +29,9 @@
 @interface Application : NXObject {
 @private
   id<ApplicationDelegate> _delegate; ///< The application delegate
-  BOOL _run;      ///< Flag to indicate if the application is running
-  NXArray *_args; ///< Command-line arguments passed to the application
+  BOOL _run;       ///< Flag to indicate if the application is running
+  int _exitstatus; ///< Exit status of the application
+  NXArray *_args;  ///< Command-line arguments passed to the application
 }
 
 /**
@@ -68,6 +69,19 @@
  * @note This method does not immediately terminate the application; it
  * simply sets a flag that will be checked in the run loop.
  */
-- (void)stop;
+- (void)terminate;
+
+/**
+ * @brief This method notifies the app that you want to exit the run loop,
+ * with a specific exit status.
+ *
+ * The remaining events in the run loop will be processed, and then the
+ * application will terminate gracefully.
+ *
+ * @note This method does not immediately terminate the application; it
+ * simply sets a flag that will be checked in the run loop. The process
+ * will exit with the specified status code.
+ */
+- (void)terminateWithExitStatus:(int)status;
 
 @end

--- a/include/NXApplication/ApplicationDelegate+Protocol.h
+++ b/include/NXApplication/ApplicationDelegate+Protocol.h
@@ -54,4 +54,30 @@
  */
 - (void)applicationWillTerminate:(id)application;
 
+/**
+ * @brief Called when the application receives a system signal.
+ * @param signal The type of signal that was received.
+ *
+ * This method is invoked when the application receives system signals such as
+ * termination requests (SIGTERM), interrupt signals (SIGINT/Ctrl+C), or quit
+ * signals (SIGQUIT). Implement this method to handle signals gracefully by
+ * performing cleanup operations, saving state, or initiating shutdown
+ * procedures.
+ *
+ * If this method is not implemented, the application will terminate
+ * with a -1 exit status when it receives a NXApplicationSignalTerm or
+ * NXApplicationSignalQuit signal. Other signals may be ignored.
+ *
+ * In the future, this method may be called for power management events,
+ * such as low or empty battery conditions, or sleep conditions, allowing
+ * applications to respond appropriately to changes in power status.
+ *
+ * @note This method may be called from a signal handler context on some
+ * platforms. Keep the implementation simple and avoid blocking operations,
+ * memory allocation, or complex system calls.
+ *
+ * @see NXApplicationSignal for available signal types.
+ */
+- (void)applicationReceivedSignal:(NXApplicationSignal)signal;
+
 @end

--- a/include/NXApplication/NXApplication.h
+++ b/include/NXApplication/NXApplication.h
@@ -56,6 +56,9 @@ int NXApplicationMain(int argc, char *argv[], Class delegate);
 @class Application;
 @class GPIO;
 
+// Types and Enums
+#import "NXApplicationTypes.h"
+
 // Protocols and Category Definitions
 #include "ApplicationDelegate+Protocol.h"
 #include "TimerDelegate+Protocol.h"

--- a/include/NXApplication/NXApplicationTypes.h
+++ b/include/NXApplication/NXApplicationTypes.h
@@ -1,0 +1,21 @@
+/**
+ * @file NXApplicationTypes.h
+ * @brief Application framework types
+ * @ingroup Application
+ *
+ * Application-related classes and types.
+ */
+#pragma once
+
+/**
+ * @brief Application signal types for handling system events.
+ * @ingroup Application
+ */
+typedef enum {
+  NXApplicationSignalNone = 0, ///< No signal
+  NXApplicationSignalTerm =
+      (1 << 0), ///< Termination signal (SIGTERM equivalent)
+  NXApplicationSignalInt =
+      (1 << 1), ///< Interrupt signal (SIGINT/Ctrl+C equivalent)
+  NXApplicationSignalQuit = (1 << 2), ///< Quit signal (SIGQUIT equivalent)
+} NXApplicationSignal;

--- a/include/runtime-gcc/objc/Object+Protocol.h
+++ b/include/runtime-gcc/objc/Object+Protocol.h
@@ -9,7 +9,7 @@
 /**
  * @brief Protocol for objects.
  * @headerfile Object+Protocol.h objc/objc.h
- * @ingroup objc 
+ * @ingroup objc
  *
  * The ObjectProtocol defines the minimal interface that objects must
  * implement to provide basic object introspection functionality.
@@ -48,5 +48,12 @@
  * otherwise.
  */
 - (BOOL)conformsTo:(Protocol *)aProtocolObject;
+
+/**
+ * @brief Checks if the receiver responds to a selector.
+ * @param aSelector The selector to check for.
+ * @return YES if the receiver responds to the specified selector, NO otherwise.
+ */
+- (BOOL)respondsToSelector:(SEL)aSelector;
 
 @end

--- a/include/runtime-gcc/objc/runtime.h
+++ b/include/runtime-gcc/objc/runtime.h
@@ -151,6 +151,16 @@ Class object_getClass(id object);
 void object_setClass(id object, Class cls);
 
 /**
+ * @brief Checks if an instance's class responds to a selector.
+ * @ingroup objc
+ * @param object The object to inspect.
+ * @param sel The selector to check.
+ * @return `YES` if instances of the class respond to the selector, `NO`
+ * otherwise.
+ */
+BOOL object_respondsToSelector(id object, SEL sel);
+
+/**
  * @brief Returns the superclass of an object.
  * @ingroup objc
  * @param obj The object to inspect.

--- a/include/runtime-sys/env.h
+++ b/include/runtime-sys/env.h
@@ -14,6 +14,65 @@ extern "C" {
 #endif
 
 /**
+ * @brief Environment signal types.
+ * @ingroup SystemEnv
+ *
+ * Enumeration of signal types that can be received from the environment
+ * or operating system. These signals typically indicate termination or
+ * interrupt requests that applications should handle gracefully.
+ */
+typedef enum {
+  SYS_ENV_SIGNAL_NONE = 0, ///< No signal
+  SYS_ENV_SIGNAL_TERM =
+      (1 << 0), ///< Termination signal (termination request from OS)
+  SYS_ENV_SIGNAL_INT =
+      (1 << 1), ///< Interrupt signal (interrupt request from user)
+  SYS_ENV_SIGNAL_QUIT = (1 << 2), ///< Quit signal (quit request from user)
+} sys_env_signal_t;
+
+/**
+ * @brief Callback function type for handling environment signals.
+ * @ingroup SystemEnv
+ * @param signal The type of signal that was received.
+ *
+ * This typedef defines the signature for callback functions that handle
+ * environment signals. The callback receives a signal type parameter
+ * indicating which signal was received.
+ */
+typedef void (*sys_env_signal_callback_t)(sys_env_signal_t signal);
+
+/**
+ * @brief Sets a handler for environment signals.
+ * @ingroup SystemEnv
+ * @param mask Bitmask of sys_env_signal_t values indicating which signals to
+ * handle. If zero, all signals are handled.
+ * @param callback The callback function to handle signals, or NULL to disable
+ * signal handling.
+ * @return true if the handler was set or cleared successfully, false if signals
+ * are not supported on this platform.
+ *
+ * This function registers a callback function that will be invoked when the
+ * application receives environment signals such as termination requests
+ * (SIGTERM), interrupt signals (SIGINT), or quit signals (SIGQUIT). The
+ * callback allows applications to perform graceful shutdown procedures when
+ * requested.
+ *
+ * Only one signal handler can be active at a time. Setting a new handler
+ * will replace any previously registered handler.
+ *
+ * Not all platforms support all signal types. Embedded platforms may have
+ * limited or no signal support.
+ *
+ * The signal handler may be called from interrupt context on some
+ * platforms. Keep the implementation simple and avoid blocking operations,
+ * memory allocation, or complex system calls within the callback.
+ *
+ * @see sys_env_signal_callback_t for callback function signature requirements.
+ */
+extern bool sys_env_signalhandler(sys_env_signal_t mask,
+                                  sys_env_signal_callback_t callback);
+
+/**
  * @brief Returns a unique identifier for the current environment.
  * @ingroup SystemEnv
  * @return A serial number or unique identifier as a string.

--- a/src/NXApplication/Application+Private.h
+++ b/src/NXApplication/Application+Private.h
@@ -22,6 +22,12 @@ void _app_timer_callback(sys_timer_t *timer);
 - (void)setArgs:(NXArray *)args;
 
 /**
+ * @brief Handles application signals.
+ * @param signal The signal received from the environment.
+ */
+- (void)signal:(NXApplicationSignal)signal;
+
+/**
  * @brief Sets the application delegate.
  * @param delegate The object to serve as the application delegate, or nil to
  * remove the current delegate.
@@ -43,6 +49,8 @@ void _app_timer_callback(sys_timer_t *timer);
 
 /**
  * @brief Starts the application's main run loop.
+ * @return An integer exit status code, which can be set with
+ * terminateWithExitStatus:
  *
  * This method begins the application's main execution cycle,
  * processing events and maintaining the application state until a

--- a/src/examples/NXApplication/gpio/main.m
+++ b/src/examples/NXApplication/gpio/main.m
@@ -26,7 +26,7 @@
   // If GPIO is not supported, log a warning and stop the application
   if ([GPIO count] == 0) {
     NXLog(@"GPIO is not supported on this platform");
-    [application stop];
+    [application terminateWithExitStatus:-1];
     return;
   }
 

--- a/src/examples/NXApplication/helloworld/main.m
+++ b/src/examples/NXApplication/helloworld/main.m
@@ -23,7 +23,7 @@
         [application args]);
 
   // Stop the application immediately after launching
-  [application stop];
+  [application terminate];
 }
 
 @end

--- a/src/examples/NXApplication/timer/main.m
+++ b/src/examples/NXApplication/timer/main.m
@@ -30,6 +30,12 @@
   NXLog(@"Timer fired = %@", timer);
 }
 
+- (void)applicationReceivedSignal:(NXApplicationSignal)signal {
+  // Handle the received signal
+  NXLog(@"Application received signal: %d", (int)signal);
+  [[Application sharedApplication] terminateWithExitStatus:0];
+}
+
 @end
 
 //////////////////////////////////////////////////////////////////////////

--- a/src/runtime-gcc/Object.m
+++ b/src/runtime-gcc/Object.m
@@ -66,4 +66,11 @@
                           (objc_protocol_t *)aProtocolObject);
 }
 
+/**
+ * @brief Checks if the receiver responds to a selector.
+ */
+- (BOOL)respondsToSelector:(SEL)aSelector {
+  return object_respondsToSelector(self, aSelector);
+}
+
 @end

--- a/src/runtime-gcc/message.c
+++ b/src/runtime-gcc/message.c
@@ -171,6 +171,23 @@ BOOL class_respondsToSelector(Class cls, SEL selector) {
              : YES; // Check if the class responds to the selector
 }
 
+BOOL object_respondsToSelector(id object, SEL selector) {
+  if (object == NULL) {
+    return NO; // If the object is nil, it cannot respond to any selector
+  }
+  if (selector == NULL) {
+    sys_panicf("object_respondsToSelector: SEL is NULL");
+    return NO;
+  }
+  Class cls = object_getClass(object);
+#ifdef DEBUG
+  sys_printf("object_respondsToSelector %c[%s %s] types=%s\n",
+             cls->info & objc_class_flag_meta ? '+' : '-', cls->name,
+             sel_getName(selector), selector->sel_type);
+#endif
+  return __objc_msg_lookup(cls, selector) == NULL ? NO : YES;
+}
+
 BOOL class_metaclassRespondsToSelector(Class cls, SEL selector) {
   if (cls == Nil) {
     return NO;

--- a/src/runtime-sys/darwin/CMakeLists.txt
+++ b/src/runtime-sys/darwin/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(${NAME} STATIC
     ../posix/memory.c
     ../posix/puts.c
     ../posix/random.c
+    ../posix/signal.c
     ../posix/sleep.c
     ../posix/timestamp.c
     ../pthreads/mutex.c

--- a/src/runtime-sys/linux/CMakeLists.txt
+++ b/src/runtime-sys/linux/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(${NAME} STATIC
     ../posix/memory.c
     ../posix/puts.c
     ../posix/random.c
+    ../posix/signal.c
     ../posix/sleep.c
     ../posix/timestamp.c
     ../pthreads/mutex.c

--- a/src/runtime-sys/pico/env.c
+++ b/src/runtime-sys/pico/env.c
@@ -118,3 +118,14 @@ const char *sys_env_name(void) { return get_program_name(); }
  * @brief Returns the version of the current environment.
  */
 const char *sys_env_version(void) { return get_program_version(); }
+
+/**
+ * @brief Sets a handler for environment signals.
+ */
+bool sys_env_signalhandler(sys_env_signal_t mask,
+                           sys_env_signal_callback_t callback) {
+  // PICO does not support signals, so we cannot set handlers
+  (void)mask;     // Suppress unused parameter warning
+  (void)callback; // Suppress unused parameter warning
+  return false;
+}

--- a/src/runtime-sys/posix/signal.c
+++ b/src/runtime-sys/posix/signal.c
@@ -1,0 +1,75 @@
+#include <runtime-sys/sys.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+static sys_env_signal_callback_t _sys_env_signal_callback_ex = NULL;
+
+static void _sys_env_signal_callback(int signo) {
+  if (_sys_env_signal_callback_ex != NULL) {
+    switch (signo) {
+    case SIGTERM:
+      _sys_env_signal_callback_ex(SYS_ENV_SIGNAL_TERM);
+      break;
+    case SIGINT:
+      _sys_env_signal_callback_ex(SYS_ENV_SIGNAL_INT);
+      break;
+    case SIGQUIT:
+      _sys_env_signal_callback_ex(SYS_ENV_SIGNAL_QUIT);
+      break;
+    default:
+      // Ignore other signals
+      return;
+    }
+  }
+}
+
+bool sys_env_signalhandler(sys_env_signal_t mask,
+                           sys_env_signal_callback_t callback) {
+  bool success = true;
+
+  // Clear previous signal handlers
+  if (mask & SYS_ENV_SIGNAL_TERM || mask == 0) {
+    if (signal(SIGTERM, SIG_DFL) == SIG_ERR) {
+      success = false; // Failed to reset handler
+    }
+  }
+  if (mask & SYS_ENV_SIGNAL_INT || mask == 0) {
+    if (signal(SIGINT, SIG_DFL) == SIG_ERR) {
+      success = false; // Failed to reset handler
+    }
+  }
+  if (mask & SYS_ENV_SIGNAL_QUIT || mask == 0) {
+    if (signal(SIGQUIT, SIG_DFL) == SIG_ERR) {
+      success = false; // Failed to reset handler
+    }
+  }
+
+  // Clear the global callback
+  _sys_env_signal_callback_ex = NULL;
+
+  // Set up new signal handlers
+  if (callback != NULL) {
+    if (mask & SYS_ENV_SIGNAL_TERM || mask == 0) {
+      if (signal(SIGTERM, _sys_env_signal_callback) == SIG_ERR) {
+        success = false; // Failed to set handler
+      }
+    }
+    if (mask & SYS_ENV_SIGNAL_INT || mask == 0) {
+      if (signal(SIGINT, _sys_env_signal_callback) == SIG_ERR) {
+        success = false; // Failed to set handler
+      }
+    }
+    if (mask & SYS_ENV_SIGNAL_QUIT || mask == 0) {
+      if (signal(SIGQUIT, _sys_env_signal_callback) == SIG_ERR) {
+        success = false; // Failed to set handler
+      }
+    }
+
+    // Set up signal handling
+    if (success) {
+      _sys_env_signal_callback_ex = callback;
+    }
+  }
+  return success;
+}


### PR DESCRIPTION
This PR adds signal handling capabilities to the application framework, allowing applications to gracefully handle system signals like SIGTERM, SIGINT, and SIGQUIT. The implementation provides a cross-platform abstraction layer with POSIX signal handling for Linux/Darwin and a no-op implementation for Pico.

Adds signal handling infrastructure to the runtime system with POSIX implementation
Integrates signal handling into the NXApplication framework with callback delegation
Updates application examples to use the new termination methods