### PR TITLE
Updated GPIO code to use statics

### DIFF
--- a/include/NXApplication/GPIO.h
+++ b/include/NXApplication/GPIO.h
@@ -5,6 +5,7 @@
  * @example examples/NXApplication/gpio/main.m
  */
 #pragma once
+#include <runtime-hw/hw.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 // CLASS DEFINITIONS
@@ -20,7 +21,8 @@
  */
 @interface GPIO : NXObject {
 @private
-  void *_data; ///< Pointer to the GPIO data
+  hw_gpio_t _pin;       ///< Pointer to the GPIO data
+  hw_gpio_mode_t _mode; ///< GPIO mode at time of initialization
 }
 
 /**
@@ -91,6 +93,37 @@
  * @return The total number of GPIO pins. Returns 0 if GPIO is not available.
  */
 + (uint8_t)count;
+
+/**
+ * @brief Returns the pin number.
+ */
+- (uint8_t)pin;
+/**
+ * @brief Returns true if the GPIO pin is configured as an input.
+ */
+- (bool)isInput;
+
+/**
+ * @brief Returns true if the GPIO pin is configured as an output.
+ */
+- (bool)isOutput;
+
+/**
+ * @brief Sets the delegate for GPIO events.
+ * @param delegate The delegate to set.
+ *
+ * This delegate will be notified of GPIO events, such as input changes.
+ * The delegate is not retained by the GPIO instance, so it must be
+ * retained by the caller. If called with nil, the current delegate will
+ * be removed.
+ */
++ (void)setDelegate:(id<GPIODelegate>)delegate;
+
+/**
+ * @brief Returns the current delegate for GPIO events.
+ * @return The current GPIO delegate, or nil if not set.
+ */
++ (id<GPIODelegate>)delegate;
 
 /**
  * @brief Returns the state of the GPIO pin.

--- a/include/NXApplication/GPIODelegate+Protocol.h
+++ b/include/NXApplication/GPIODelegate+Protocol.h
@@ -1,0 +1,33 @@
+/**
+ * @file GPIODelegate+Protocol.h
+ * @brief Defines a protocol for the GPIO delegate.
+ *
+ * The GPIODelegate protocol defines methods that are called by the
+ * run loop when a GPIO event occurs.
+ */
+#pragma once
+#include "GPIOTypes.h"
+
+/**
+ * @protocol GPIODelegate
+ * @ingroup Application
+ * @headerfile GPIODelegate+Protocol.h NXApplication/NXApplication.h
+ * @brief A protocol that defines the methods for a GPIO delegate.
+ */
+@protocol GPIODelegate
+
+@required
+
+/**
+ * @brief Called when the GPIO input changes.
+ * @param sender The GPIO that triggered the event.
+ * @param event The event that occurred.
+ *
+ * This method is called when the GPIO input changes, either GPIOEventRising
+ * (from low to high) or GPIOEventFalling (from high to low). When both edges
+ * are detected, the event will include both GPIOEventRising and
+ * GPIOEventFalling (GPIOEventChanged).
+ */
+- (void)gpio:(id)sender changed:(GPIOEvent)event;
+
+@end

--- a/include/NXApplication/GPIOTypes.h
+++ b/include/NXApplication/GPIOTypes.h
@@ -1,6 +1,6 @@
 
 /**
- * @file GPIOInputTypes.h
+ * @file GPIOTypes.h
  * @brief GPIO input types for handling GPIO events.
  * @ingroup Application
  *

--- a/include/NXApplication/GPIOTypes.h
+++ b/include/NXApplication/GPIOTypes.h
@@ -1,0 +1,21 @@
+
+/**
+ * @file GPIOInputTypes.h
+ * @brief GPIO input types for handling GPIO events.
+ * @ingroup Application
+ *
+ * GPIO-related types.
+ */
+#pragma once
+#include <runtime-hw/hw.h>
+
+/**
+ * @brief GPIO input types for handling GPIO events.
+ * @ingroup Application
+ */
+typedef enum {
+  GPIOEventRising = HW_GPIO_RISING,   ///< Rising edge detected
+  GPIOEventFalling = HW_GPIO_FALLING, ///< Falling edge detected
+  GPIOEventChanged =
+      GPIOEventRising | GPIOEventFalling, ///< Both edges detected
+} GPIOEvent;

--- a/include/NXApplication/NXApplication.h
+++ b/include/NXApplication/NXApplication.h
@@ -61,6 +61,7 @@ int NXApplicationMain(int argc, char *argv[], Class delegate);
 
 // Protocols and Category Definitions
 #include "ApplicationDelegate+Protocol.h"
+#include "GPIODelegate+Protocol.h"
 #include "TimerDelegate+Protocol.h"
 
 // Class Definitions

--- a/include/runtime-hw/gpio.h
+++ b/include/runtime-hw/gpio.h
@@ -18,6 +18,14 @@
 // TYPES
 
 /**
+ * @brief Maximum number of GPIO pins.
+ * @ingroup GPIO
+ *
+ * The maximum number of GPIO pins that is supported in this runtime.
+ */
+#define HW_GPIO_MAX_COUNT 50
+
+/**
  * @brief GPIO mode flags for configuring GPIO pins.
  * @ingroup GPIO
  */
@@ -83,6 +91,9 @@ typedef void (*hw_gpio_callback_t)(uint8_t pin, hw_gpio_event_t event,
  * Returns the number of logical GPIO pins that can be used in the system.
  * These are usually numbered from 0 to hw_gpio_count() - 1.
  * If zero is returned, it indicates that GPIO functionality is not available.
+ *
+ * It will never return more than HW_GPIO_MAX_COUNT as this is a hard
+ * limit on the number of supported GPIO pins.
  */
 uint8_t hw_gpio_count(void);
 

--- a/src/NXApplication/Application.m
+++ b/src/NXApplication/Application.m
@@ -1,3 +1,4 @@
+#include "GPIO+Private.h"
 #include "NXTimer+Private.h"
 #include <NXApplication/NXApplication.h>
 #include <runtime-hw/hw.h>
@@ -265,11 +266,7 @@ void _app_poll_callback(sys_timer_t *timer) {
       hw_poll();
       break;
     case APP_EVENT_GPIO:
-      // Handle GPIO event
-      sys_printf(
-          "core %d: Processing GPIO event: pin=%u event=%u (queue size=%d)\n",
-          sys_thread_core(), app_event->pin, app_event->event,
-          sys_event_queue_size(&_app_queue));
+      _gpio_callback(app_event->pin, app_event->event);
       break;
     case APP_EVENT_TIMER: {
       // sender is stored as void* in the event; cast to id before messaging

--- a/src/NXApplication/GPIO+Private.h
+++ b/src/NXApplication/GPIO+Private.h
@@ -1,0 +1,25 @@
+/**
+ * @file GPIO+Private.h
+ * @brief GPIO class private header.
+ */
+#pragma once
+#include <NXApplication/NXApplication.h>
+#include <runtime-hw/hw.h>
+
+/**
+ * @brief Callback for GPIO events.
+ */
+void _gpio_callback(uint8_t pin, hw_gpio_event_t event);
+
+/**
+ * @brief Category for private methods of the GPIO class.
+ */
+@interface GPIO (Private)
+
+/**
+ * @brief Calls the delegate's gpio:changed: method. If GPIO is subclassed,
+ * the subclass's implementation will be called instead.
+ */
+- (void)changed:(GPIOEvent)event;
+
+@end

--- a/src/NXApplication/GPIO.m
+++ b/src/NXApplication/GPIO.m
@@ -1,7 +1,37 @@
+#include "GPIO+Private.h"
 #include <NXApplication/NXApplication.h>
 #include <NXFoundation/NXFoundation.h>
 #include <runtime-hw/hw.h>
 #include <runtime-sys/sys.h>
+
+///////////////////////////////////////////////////////////////////////////////
+// GLOBAL VARIABLES
+
+// Delegate
+static id<GPIODelegate> _gpioDelegate = nil;
+
+// GPIO instances
+static GPIO *_gpio[HW_GPIO_MAX_COUNT] = {0};
+
+///////////////////////////////////////////////////////////////////////////////
+// CALLBACKS
+
+void _gpio_callback(uint8_t pin, hw_gpio_event_t event) {
+  if (event == 0) {
+    return; // No event to process
+  }
+  if (pin >= HW_GPIO_MAX_COUNT) {
+    return; // Invalid pin number
+  }
+
+  // Get the GPIO instance for the pin
+  GPIO *gpio = _gpio[pin];
+  if (gpio) {
+    [gpio changed:(GPIOEvent)event];
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
 
 @implementation GPIO
 
@@ -17,22 +47,20 @@
     return nil; // Initialization failed
   }
 
+  // Check maximum number of pins
+  if (pin >= hw_gpio_count()) {
+    [self release];
+    return nil;
+  }
+
   // Get the pin
-  hw_gpio_t gpio = hw_gpio_init(pin, mode);
-  if (gpio.mask == 0) {
+  _pin = hw_gpio_init(pin, mode);
+  if (hw_gpio_valid(&_pin) == false) {
     // Invalid pin initialization
     [self release];
     return nil;
   } else {
-    _data = sys_malloc(sizeof(hw_gpio_t));
-    if (_data == NULL) {
-      // Memory allocation failed
-      [self release];
-      return nil;
-    } else {
-      // Store the pin data
-      sys_memcpy(_data, &gpio, sizeof(hw_gpio_t));
-    }
+    _mode = hw_gpio_get_mode(&_pin);
   }
 
   // Return success
@@ -40,10 +68,9 @@
 }
 
 - (void)dealloc {
-  if (_data) {
-    sys_free(_data);
-    _data = NULL;
-  }
+  sys_assert(self == _gpio[_pin.pin]);
+  hw_gpio_finalize(&_pin);
+  _gpio[_pin.pin] = nil; // Clear the static GPIO instance
   [super dealloc];
 }
 
@@ -51,28 +78,84 @@
  * @brief Returns a GPIO input instance.
  */
 + (GPIO *)inputWithPin:(uint8_t)pin {
-  return [[[self alloc] initPin:pin mode:HW_GPIO_INPUT] autorelease];
+  // Check input arguments
+  if (pin >= hw_gpio_count() || pin >= HW_GPIO_MAX_COUNT) {
+    return nil; // Invalid pin number
+  }
+
+  // Get or create static instance of GPIO pin
+  @synchronized(self) {
+    GPIO *gpio = _gpio[pin];
+    if (gpio == nil) {
+      _gpio[pin] = [[self alloc] initPin:pin mode:HW_GPIO_INPUT];
+    }
+
+    // Return retained instance
+    return _gpio[pin];
+  }
 }
 
 /**
  * @brief Returns a GPIO input instance, with pull-up resistor enabled.
  */
 + (GPIO *)pullupWithPin:(uint8_t)pin {
-  return [[[self alloc] initPin:pin mode:HW_GPIO_PULLUP] autorelease];
+  // Check input arguments
+  if (pin >= hw_gpio_count() || pin >= HW_GPIO_MAX_COUNT) {
+    return nil; // Invalid pin number
+  }
+
+  // Get or create static instance of GPIO pin
+  @synchronized(self) {
+    GPIO *gpio = _gpio[pin];
+    if (gpio == nil) {
+      _gpio[pin] = [[self alloc] initPin:pin mode:HW_GPIO_PULLUP];
+    }
+
+    // Return retained instance
+    return _gpio[pin];
+  }
 }
 
 /**
  * @brief Returns a GPIO input instance, with pull-down resistor enabled.
  */
 + (GPIO *)pulldownWithPin:(uint8_t)pin {
-  return [[[self alloc] initPin:pin mode:HW_GPIO_PULLDOWN] autorelease];
+  // Check input arguments
+  if (pin >= hw_gpio_count() || pin >= HW_GPIO_MAX_COUNT) {
+    return nil; // Invalid pin number
+  }
+
+  // Get or create static instance of GPIO pin
+  @synchronized(self) {
+    GPIO *gpio = _gpio[pin];
+    if (gpio == nil) {
+      _gpio[pin] = [[self alloc] initPin:pin mode:HW_GPIO_PULLDOWN];
+    }
+
+    // Return retained instance
+    return _gpio[pin];
+  }
 }
 
 /**
  * @brief Returns a GPIO output instance.
  */
 + (GPIO *)outputWithPin:(uint8_t)pin {
-  return [[[self alloc] initPin:pin mode:HW_GPIO_OUTPUT] autorelease];
+  // Check input arguments
+  if (pin >= hw_gpio_count() || pin >= HW_GPIO_MAX_COUNT) {
+    return nil; // Invalid pin number
+  }
+
+  // Get or create static instance of GPIO pin
+  @synchronized(self) {
+    GPIO *gpio = _gpio[pin];
+    if (gpio == nil) {
+      _gpio[pin] = [[self alloc] initPin:pin mode:HW_GPIO_OUTPUT];
+    }
+
+    // Return retained instance
+    return _gpio[pin];
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -86,18 +169,51 @@
   return hw_gpio_count();
 }
 
+/**
+ * @brief Returns the pin number.
+ */
+- (uint8_t)pin {
+  return _pin.pin;
+}
+
+/**
+ * @brief Returns true if the GPIO pin is configured as an input.
+ */
+- (bool)isInput {
+  return _mode == HW_GPIO_INPUT || _mode == HW_GPIO_PULLUP ||
+         _mode == HW_GPIO_PULLDOWN;
+}
+
+/**
+ * @brief Returns true if the GPIO pin is configured as an output.
+ */
+- (bool)isOutput {
+  return _mode == HW_GPIO_OUTPUT;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // METHODS
+
++ (void)setDelegate:(id<GPIODelegate>)delegate {
+  @synchronized(self) {
+    // Set the GPIO delegate
+    _gpioDelegate = delegate;
+  }
+}
+
++ (id<GPIODelegate>)delegate {
+  @synchronized(self) {
+    return _gpioDelegate;
+  }
+}
 
 /**
  * @brief Returns the state of the GPIO pin.
  * @return true if the pin is high (logical 1), false if low (logical 0).
  */
 - (BOOL)state {
-  objc_assert(_data);
-  hw_gpio_t *pin = (hw_gpio_t *)_data;
-  objc_assert(pin->mask);
-  return hw_gpio_get(pin);
+  objc_assert(hw_gpio_valid(&_pin));
+  return hw_gpio_get(&_pin);
 }
 
 /**
@@ -106,19 +222,27 @@
  * 0).
  */
 - (void)setState:(BOOL)state {
-  objc_assert(_data);
-  hw_gpio_t *pin = (hw_gpio_t *)_data;
-  objc_assert(pin->mask);
-  hw_gpio_set(pin, state);
+  objc_assert(hw_gpio_valid(&_pin));
+  hw_gpio_set(&_pin, state);
+}
+
+/**
+ * @brief Calls the delegate's gpio:changed: method. If GPIO is subclassed,
+ * the subclass's implementation will be called instead.
+ */
+- (void)changed:(GPIOEvent)event {
+  // Call the delegate GPIO event handler
+  if (_gpioDelegate &&
+      object_respondsToSelector(_gpioDelegate, @selector(gpio:changed:))) {
+    [_gpioDelegate gpio:self changed:(GPIOEvent)event];
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // OBJECT PROTOCOLS
 
 - (NXString *)description {
-  objc_assert(_data);
-  hw_gpio_t *pin = (hw_gpio_t *)_data;
-  return [NXString stringWithFormat:@"(gpio pin=%d)", pin->pin];
+  return [NXString stringWithFormat:@"(gpio pin=%d)", (int)_pin.pin];
 }
 
 @end

--- a/src/NXApplication/GPIO.m
+++ b/src/NXApplication/GPIO.m
@@ -70,7 +70,11 @@ void _gpio_callback(uint8_t pin, hw_gpio_event_t event) {
 - (void)dealloc {
   sys_assert(self == _gpio[_pin.pin]);
   hw_gpio_finalize(&_pin);
-  _gpio[_pin.pin] = nil; // Clear the static GPIO instance
+  if (self == _gpio[_pin.pin]) {
+    sys_assert(self == _gpio[_pin.pin]);
+    _gpio[_pin.pin] = nil; // Clear the static GPIO instance
+  }
+  hw_gpio_finalize(&_pin);
   [super dealloc];
 }
 

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -21,9 +21,9 @@ add_subdirectory(runtime/wifiscan)
 add_subdirectory(runtime/wificonnect)
 
 # NXApplication examples
-#add_subdirectory(NXApplication/helloworld)
-#add_subdirectory(NXApplication/gpio)
-#add_subdirectory(NXApplication/timer)
+add_subdirectory(NXApplication/helloworld)
+add_subdirectory(NXApplication/gpio)
+add_subdirectory(NXApplication/timer)
 
 # Driver examples
 add_subdirectory(drivers/bme280)

--- a/src/examples/NXApplication/gpio/CMakeLists.txt
+++ b/src/examples/NXApplication/gpio/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(${NAME} PRIVATE
 )
 
 # additional configurations for the Pico SDK
-if(CMAKE_SYSTEM_NAME STREQUAL "Pico")
+if(CMAKE_SYSTEM_NAME STREQUAL "PICO")
 pico_add_extra_outputs(${NAME})
 pico_enable_stdio_usb(${NAME} 1)
 pico_enable_stdio_uart(${NAME} 0)

--- a/src/examples/NXApplication/gpio/hack.c
+++ b/src/examples/NXApplication/gpio/hack.c
@@ -1,4 +1,6 @@
+// Provide weak placeholders for stdout/stderr for bare-metal builds.
+// The Pico SDK/picolibc provides strong definitions; these will be ignored.
 #include <stddef.h>
 
-void *stdout = NULL; // Placeholder for standard output
-void *stderr = NULL; // Placeholder for standard error
+__attribute__((weak)) void *stdout = NULL;
+__attribute__((weak)) void *stderr = NULL;

--- a/src/examples/NXApplication/gpio/main.m
+++ b/src/examples/NXApplication/gpio/main.m
@@ -8,14 +8,14 @@
  */
 #include <NXApplication/NXApplication.h>
 
-#define GPIO_BOOTSEL 23 // BOOTSEL Button
+#define GPIO_BOOTSEL 30 // BOOTSEL Button
 #define GPIO_A 12       // Button A
 #define GPIO_B 13       // Button B
 #define GPIO_C 14       // Button C
 
 //////////////////////////////////////////////////////////////////////////
 
-@interface MyAppDelegate : NXObject <ApplicationDelegate>
+@interface MyAppDelegate : NXObject <ApplicationDelegate, GPIODelegate>
 @end
 
 //////////////////////////////////////////////////////////////////////////
@@ -30,11 +30,32 @@
     return;
   }
 
+  // Set GPIO delegate
+  [GPIO setDelegate:self];
+
   // Initialize a GPIO pin for input
   [GPIO pullupWithPin:GPIO_A];
   [GPIO pullupWithPin:GPIO_B];
   [GPIO pullupWithPin:GPIO_C];
   [GPIO inputWithPin:GPIO_BOOTSEL];
+}
+
+- (void)gpio:(GPIO *)gpio changed:(GPIOEvent)event {
+  // Handle GPIO events
+  switch (event) {
+  case GPIOEventRising:
+    NXLog(@"GPIO pin %d rising edge detected", [gpio pin]);
+    break;
+  case GPIOEventFalling:
+    NXLog(@"GPIO pin %d falling edge detected", [gpio pin]);
+    break;
+  case GPIOEventChanged:
+    NXLog(@"GPIO pin %d state change (rising & falling)", [gpio pin]);
+    break;
+  default:
+    NXLog(@"Unknown GPIO event for pin %d", [gpio pin]);
+    break;
+  }
 }
 
 @end

--- a/src/examples/NXApplication/helloworld/CMakeLists.txt
+++ b/src/examples/NXApplication/helloworld/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(${NAME} PRIVATE
 )
 
 # additional configurations for the Pico SDK
-if(CMAKE_SYSTEM_NAME STREQUAL "Pico")
+if(CMAKE_SYSTEM_NAME STREQUAL "PICO")
     pico_add_extra_outputs(${NAME})
     pico_enable_stdio_usb(${NAME} 1)
     pico_enable_stdio_uart(${NAME} 0)

--- a/src/examples/NXApplication/helloworld/hack.c
+++ b/src/examples/NXApplication/helloworld/hack.c
@@ -1,4 +1,6 @@
+// Provide weak placeholders for stdout/stderr for bare-metal builds.
+// The Pico SDK/picolibc provides strong definitions; these will be ignored.
 #include <stddef.h>
 
-void *stdout = NULL; // Placeholder for standard output
-void *stderr = NULL; // Placeholder for standard error
+__attribute__((weak)) void *stdout = NULL;
+__attribute__((weak)) void *stderr = NULL;

--- a/src/examples/NXApplication/timer/CMakeLists.txt
+++ b/src/examples/NXApplication/timer/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(${NAME} PRIVATE
 )
 
 # additional configurations for the Pico SDK
-if(CMAKE_SYSTEM_NAME STREQUAL "Pico")
+if(CMAKE_SYSTEM_NAME STREQUAL "PICO")
 pico_add_extra_outputs(${NAME})
 pico_enable_stdio_usb(${NAME} 1)
 pico_enable_stdio_uart(${NAME} 0)

--- a/src/examples/NXApplication/timer/hack.c
+++ b/src/examples/NXApplication/timer/hack.c
@@ -1,4 +1,6 @@
+// Provide weak placeholders for stdout/stderr for bare-metal builds.
+// The Pico SDK/picolibc provides strong definitions; these will be ignored.
 #include <stddef.h>
 
-void *stdout = NULL; // Placeholder for standard output
-void *stderr = NULL; // Placeholder for standard error
+__attribute__((weak)) void *stdout = NULL;
+__attribute__((weak)) void *stderr = NULL;

--- a/src/runtime-hw/pico/gpio.c
+++ b/src/runtime-hw/pico/gpio.c
@@ -55,7 +55,13 @@ void hw_gpio_finalize(hw_gpio_t *gpio) {
 /**
  * @brief Get the total number of available GPIO pins.
  */
-uint8_t hw_gpio_count(void) { return NUM_BANK0_GPIOS; }
+uint8_t hw_gpio_count(void) {
+  int max = NUM_BANK0_GPIOS;
+  if (max > HW_GPIO_MAX_COUNT) {
+    max = HW_GPIO_MAX_COUNT;
+  }
+  return max;
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 // PUBLIC METHODS


### PR DESCRIPTION
This PR refactors the GPIO implementation to use static instances instead of creating new instances on each access, adds GPIO event handling through delegates, and includes various build fixes for Pico platform support.

* Converts GPIO instance creation to use static singleton pattern with synchronization
* Implements GPIO event delegation system with callback support
* Fixes CMAKE system name detection for Pico platform builds