### PR TITLE
Djt 0906 dirs

### DIFF
--- a/include/runtime-fs/fs.h
+++ b/include/runtime-fs/fs.h
@@ -31,6 +31,7 @@ typedef struct fs_volume_t fs_volume_t; ///< Opaque filesystem volume handle
 
 /**
  * @brief File and directory metadata.
+ * @ingroup FileSystem
  */
 typedef struct {
   fs_volume_t *volume;        ///< Owning volume (set by APIs)
@@ -49,6 +50,7 @@ typedef struct {
 
 /**
  * @brief Create a new volatile (RAM) filesystem volume.
+ * @ingroup FileSystem
  *
  * @param size Requested minimum size in bytes (rounded up to block geometry).
  * @return Pointer to mounted volume on success, NULL on failure.
@@ -61,6 +63,7 @@ extern fs_volume_t *fs_vol_init_memory(size_t size);
 
 /**
  * @brief Open or create a host file–backed persistent volume.
+ * @ingroup FileSystem
  *
  * Attempts to mount the filesystem stored in @p path. If mounting fails, a
  * format is performed and a fresh filesystem created. If the file is shorter
@@ -74,6 +77,7 @@ extern fs_volume_t *fs_vol_init_file(const char *path, size_t size);
 
 /**
  * @brief Unmount and release all resources for a volume.
+ * @ingroup FileSystem
  *
  * @param volume Volume returned from an init call (may be NULL).
  *
@@ -83,6 +87,7 @@ extern void fs_vol_finalize(fs_volume_t *volume);
 
 /**
  * @brief Return total addressable size of a mounted volume.
+ * @ingroup FileSystem
  *
  * @param volume Volume handle.
  * @param free Pointer to size_t to receive approximate free space in bytes (may
@@ -93,6 +98,7 @@ extern size_t fs_vol_size(fs_volume_t *volume, size_t *free);
 
 /**
  * @brief Iterate directory entries.
+ * @ingroup FileSystem
  *
  * @param volume Mounted volume.
  * @param path Directory path ("/" for root). NULL treated as root.
@@ -104,6 +110,7 @@ extern bool fs_vol_readdir(fs_volume_t *volume, const char *path,
 
 /**
  * @brief Lookup file or directory metadata for a path.
+ * @ingroup FileSystem
  *
  * @param volume Mounted volume.
  * @param path Absolute path within volume (NULL/empty -> root).
@@ -113,6 +120,7 @@ extern fs_file_t fs_vol_stat(fs_volume_t *volume, const char *path);
 
 /**
  * @brief Create a directory.
+ * @ingroup FileSystem
  *
  * @param volume Mounted volume.
  * @param path New directory path (parents must already exist).
@@ -122,15 +130,17 @@ extern bool fs_vol_mkdir(fs_volume_t *volume, const char *path);
 
 /**
  * @brief Remove a file or (empty) directory.
+ * @ingroup FileSystem
  *
  * @param volume Mounted volume.
  * @param path Path to remove.
  * @return true on success; false if not found or directory not empty.
  */
-extern bool fs_vol_delete(fs_volume_t *volume, const char *path);
+extern bool fs_vol_remove(fs_volume_t *volume, const char *path);
 
 /**
  * @brief Move or rename a file/directory.
+ * @ingroup FileSystem
  *
  * @param volume Mounted volume.
  * @param old_path Existing path.
@@ -139,3 +149,64 @@ extern bool fs_vol_delete(fs_volume_t *volume, const char *path);
  */
 extern bool fs_vol_move(fs_volume_t *volume, const char *old_path,
                         const char *new_path);
+
+/**
+ * @brief Create a new file or truncate an existing file to zero length.
+ * @ingroup FileSystem
+ *
+ * @param volume Mounted volume.
+ * @param path Path to create.
+ * @return Opened read/write file, or zeroed struct on failure.
+ */
+fs_file_t fs_file_create(fs_volume_t *volume, const char *path);
+
+/**
+ * @brief Open an existing file for read/write.
+ * @ingroup FileSystem
+ *
+ * @param volume Mounted volume.
+ * @param path File path to open.
+ * @param write True to open for writing, false for read-only.
+ * @return Opened file, or zeroed struct on failure.
+ */
+fs_file_t fs_file_open(fs_volume_t *volume, const char *path, bool write);
+
+/**
+ * @brief Close an opened file.
+ * @ingroup FileSystem
+ *
+ * @param file File to close.
+ */
+bool fs_file_close(fs_file_t *file);
+
+/**
+ * @brief Read data from an opened file.
+ * @ingroup FileSystem
+ *
+ * @param file File to read from.
+ * @param buffer Buffer to read data into.
+ * @param size Number of bytes to read (cannot be zero).
+ * @return Number of bytes read, or 0 on error.
+ */
+size_t fs_file_read(fs_file_t *file, void *buffer, size_t size);
+
+/**
+ * @brief Write data from an opened file.
+ * @ingroup FileSystem
+ *
+ * @param file File to write to.
+ * @param buffer Buffer to write data from.
+ * @param size Number of bytes to write (cannot be zero).
+ * @return Number of bytes written, or 0 on error.
+ */
+size_t fs_file_write(fs_file_t *file, const void *buffer, size_t size);
+
+/**
+ * @brief Seek to a position within an opened file.
+ * @ingroup FileSystem
+ *
+ * @param file File to seek.
+ * @param offset Offset in bytes from the beginning of the file.
+ * @return true on success, false on error.
+ */
+bool fs_file_seek(fs_file_t *file, size_t offset);

--- a/include/runtime-fs/fs.h
+++ b/include/runtime-fs/fs.h
@@ -204,7 +204,7 @@ bool fs_file_close(fs_file_t *file);
 size_t fs_file_read(fs_file_t *file, void *buffer, size_t size);
 
 /**
- * @brief Write data from an opened file.
+ * @brief Write data to an opened file.
  * @ingroup FileSystem
  *
  * @param file File to write to.

--- a/include/runtime-fs/fs.h
+++ b/include/runtime-fs/fs.h
@@ -76,6 +76,19 @@ extern fs_volume_t *fs_vol_init_memory(size_t size);
 extern fs_volume_t *fs_vol_init_file(const char *path, size_t size);
 
 /**
+ * @brief Open or create a non-volatile flash-backed persistent volume.
+ * @ingroup FileSystem
+ *
+ * Attempts to mount the filesystem stored in flash memory. The location of
+ * the volume in flash memory is implementation-specific. If
+ * mounting fails, a format is performed and a fresh filesystem created.
+ *
+ * @param size Minimum size in bytes; ignored if existing file is larger.
+ * @return Mounted volume pointer, or NULL on error.
+ */
+extern fs_volume_t *fs_vol_init_flash(size_t size);
+
+/**
  * @brief Unmount and release all resources for a volume.
  * @ingroup FileSystem
  *

--- a/src/runtime-fs/littlefs/volume.c
+++ b/src/runtime-fs/littlefs/volume.c
@@ -86,10 +86,26 @@ fs_file_t fs_vol_stat(fs_volume_t *volume, const char *path) {
 /**
  * @brief Remove a file or (empty) directory.
  */
-bool fs_vol_delete(fs_volume_t *volume, const char *path) {
+bool fs_vol_remove(fs_volume_t *volume, const char *path) {
   sys_assert(volume);
   if (path == NULL || *path == '\0' || sys_strcmp(path, "/") == 0) {
-    return false; // cannot delete root
+    return false; // cannot remove root
   }
   return lfs_remove(&volume->lfs, path) == 0 ? true : false;
+}
+
+/**
+ * @brief Move or rename a file/directory.
+ */
+bool fs_vol_move(fs_volume_t *volume, const char *old_path,
+                 const char *new_path) {
+  sys_assert(volume);
+  if (old_path == NULL || *old_path == '\0' || sys_strcmp(old_path, "/") == 0 ||
+      new_path == NULL || *new_path == '\0' || sys_strcmp(new_path, "/") == 0) {
+    return false; // cannot move root
+  }
+  if (sys_strcmp(old_path, new_path) == 0) {
+    return true; // no-op
+  }
+  return lfs_rename(&volume->lfs, old_path, new_path) == 0 ? true : false;
 }

--- a/src/tests/fs/fs_04/main.c
+++ b/src/tests/fs/fs_04/main.c
@@ -64,7 +64,7 @@ static void delete_tree(fs_volume_t *vol) {
   for (int d = 0; d < STRESS_DEPTH; ++d) {
     for (int i = 0; i < STRESS_DIR_COUNT; i++) {
       make_path(path, sizeof(path), "/", d, i);
-      bool ok = fs_vol_delete(vol, path);
+      bool ok = fs_vol_remove(vol, path);
       test_assert(ok);
     }
   }


### PR DESCRIPTION
This PR renames the fs_vol_delete function to fs_vol_remove and adds new file system functionality including a move/rename operation and file I/O APIs. The change improves API consistency by using the more standard "remove" terminology for file deletion operations.

Key changes:
* Renamed fs_vol_delete to fs_vol_remove for better naming consistency
* Added fs_vol_move function for file/directory renaming and moving
* Added comprehensive file I/O API functions (create, open, close, read, write, seek)